### PR TITLE
Make ERRP notices durable and retryable

### DIFF
--- a/automation/errp_notify.php
+++ b/automation/errp_notify.php
@@ -33,63 +33,131 @@ try {
     exit(1);
 }
 
-function sendRenewalReminderEmail($to_email, $domainName, $expiresAt, $days_until_expiry, $config, $log) {
-    $template = match ((int)$days_until_expiry) {
-        30 => 'errp_30_days',
-        7  => 'errp_7_days',
-        1  => 'errp_1_day',
-        -5 => 'errp_expired',
+function getErrpTemplate(int $daysUntilExpiry): ?string
+{
+    return match (true) {
+        $daysUntilExpiry <= 30 && $daysUntilExpiry >= 25 => 'errp_30_days',
+        $daysUntilExpiry <= 7 && $daysUntilExpiry >= 4 => 'errp_7_days',
+        $daysUntilExpiry === 1 => 'errp_1_day',
+        $daysUntilExpiry <= -1 && $daysUntilExpiry >= -5 => 'errp_expired',
         default => null,
     };
+}
 
-    if ($template === null) {
-        return;
-    }
-
+function sendRenewalReminderEmail(
+    DriverInterface $driver,
+    int $domainId,
+    string $toEmail,
+    string $domainName,
+    string $expiresAt,
+    int $daysUntilExpiry,
+    string $template,
+    array $config,
+    $log
+): void {
     $email = render_email_template(
         $template,
         [
             'domain_name' => $domainName,
             'expires_at' => $expiresAt,
-            'days_until_expiry' => $days_until_expiry,
+            'days_until_expiry' => $daysUntilExpiry,
         ],
         $config
     );
 
-    if (send_email($to_email, $email['subject'], $email['body'], $config, $log, $email['html'])) {
-        $log->info("ERRP notice sent for domain $domainName.");
-    } else {
-        $log->error("ERRP notice delivery failed for domain $domainName.");
+    if (!send_email(
+        $toEmail,
+        $email['subject'],
+        $email['body'],
+        $config,
+        $log,
+        $email['html']
+    )) {
+        $log->error("ERRP notice delivery failed for domain {$domainName}.");
+        return;
     }
+
+    $driver->storeErrpNotification([
+        'domain_id' => $domainId,
+        'domain' => $domainName,
+        'type' => $template,
+        'recipient' => $toEmail,
+        'subject' => $email['subject'],
+        'body' => $email['body'],
+        'metadata' => [
+            'expires_at' => (new DateTimeImmutable($expiresAt))->format('Y-m-d'),
+            'days_until_expiry' => $daysUntilExpiry,
+            'html' => $email['html'],
+        ],
+        'sent_at' => gmdate('Y-m-d H:i:s'),
+    ]);
+
+    $log->info(
+        "ERRP notice {$template} sent for domain {$domainName}."
+    );
 }
 
-function sendRenewalReminders(DriverInterface $driver, $log, $config) {
+function sendRenewalReminders(
+    DriverInterface $driver,
+    $log,
+    array $config
+): void {
     try {
-        $expiring_domains = $driver->getErrpDomains();
+        $expiringDomains = $driver->getErrpDomains();
 
-        foreach ($expiring_domains as $domain) {
-            $domainExpiration = $domain['expires_at'];
-            $domainEmail = $domain['email'];
-            $domainName = $domain['domain_name'];
+        foreach ($expiringDomains as $domain) {
+            $domainId = (int)$domain['domain_id'];
+            $domainExpiration = (string)$domain['expires_at'];
+            $domainEmail = (string)$domain['email'];
+            $domainName = (string)$domain['domain_name'];
 
-            $expiry_date = (new DateTime($domainExpiration))->setTime(0, 0, 0);
-            $now = (new DateTime())->setTime(0, 0, 0);
-            $days_until_expiry = (int)$now->diff($expiry_date)->format('%r%a');
+            $expiryDate = (new DateTimeImmutable($domainExpiration))
+                ->setTime(0, 0);
+            $now = (new DateTimeImmutable())->setTime(0, 0);
+            $daysUntilExpiry = (int)$now
+                ->diff($expiryDate)
+                ->format('%r%a');
+            $template = getErrpTemplate($daysUntilExpiry);
 
-            if ($days_until_expiry == 30 || $days_until_expiry == 7 || $days_until_expiry == 1 || $days_until_expiry == -5) {
-                if (!empty($domainEmail) && filter_var($domainEmail, FILTER_VALIDATE_EMAIL)) {
-                    sendRenewalReminderEmail($domainEmail, $domainName, $domainExpiration, $days_until_expiry, $config, $log);
-                } else {
-                    $log->warning("Skipping {$domainName}: no valid email found for reminder ({$days_until_expiry}d).");
-                }
+            if ($template === null) {
+                continue;
             }
+
+            if ($driver->hasErrpNotification(
+                $domainId,
+                $template,
+                $expiryDate->format('Y-m-d')
+            )) {
+                continue;
+            }
+
+            if (
+                $domainEmail === ''
+                || !filter_var($domainEmail, FILTER_VALIDATE_EMAIL)
+            ) {
+                $log->warning(
+                    "Skipping {$domainName}: no valid registrant email "
+                    . "found for {$template}."
+                );
+                continue;
+            }
+
+            sendRenewalReminderEmail(
+                $driver,
+                $domainId,
+                $domainEmail,
+                $domainName,
+                $domainExpiration,
+                $daysUntilExpiry,
+                $template,
+                $config,
+                $log
+            );
         }
+
         $log->info('job completed.');
     } catch (PDOException $e) {
         $log->error('Database error: ' . $e->getMessage());
-        exit(1);
-    } catch (Exception $e) {
-        $log->error('Error: ' . $e->getMessage());
         exit(1);
     } catch (Throwable $e) {
         $log->error('Error: ' . $e->getMessage());

--- a/automation/src/Backend/Custom.php
+++ b/automation/src/Backend/Custom.php
@@ -79,6 +79,20 @@ class Custom extends AbstractDriver
         throw $this->notImplemented(__FUNCTION__);
     }
 
+    public function hasErrpNotification(
+        int $domainId,
+        string $type,
+        string $expirationDate
+    ): bool
+    {
+        throw $this->notImplemented(__FUNCTION__);
+    }
+
+    public function storeErrpNotification(array $data): void
+    {
+        throw $this->notImplemented(__FUNCTION__);
+    }
+
     public function getExpiredDomains(): array
     {
         throw $this->notImplemented(__FUNCTION__);

--- a/automation/src/Backend/DriverInterface.php
+++ b/automation/src/Backend/DriverInterface.php
@@ -32,6 +32,14 @@ interface DriverInterface
 
     public function getErrpDomains(): array;
 
+    public function hasErrpNotification(
+        int $domainId,
+        string $type,
+        string $expirationDate
+    ): bool;
+
+    public function storeErrpNotification(array $data): void;
+
     public function getExpiredDomains(): array;
 
     public function updateExpiredDomainNameservers(array $row, string $ns1, string $ns2): void;

--- a/automation/src/Backend/FOSS.php
+++ b/automation/src/Backend/FOSS.php
@@ -568,7 +568,8 @@ final class FOSS extends AbstractDriver
     public function getErrpDomains(): array
     {
         $stmt = $this->pdo->prepare("
-            SELECT CONCAT(sld, '.', tld) AS domain_name,
+            SELECT id AS domain_id,
+                   CONCAT(sld, '.', tld) AS domain_name,
                    expires_at,
                    contact_email AS email
             FROM service_domain
@@ -578,6 +579,48 @@ final class FOSS extends AbstractDriver
         $stmt->execute();
 
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    public function hasErrpNotification(
+        int $domainId,
+        string $type,
+        string $expirationDate
+    ): bool
+    {
+        $stmt = $this->pdo->prepare("
+            SELECT 1
+            FROM domain_registrar_notification
+            WHERE domain_id = ?
+              AND type = ?
+              AND JSON_UNQUOTE(JSON_EXTRACT(metadata, '$.expires_at')) = ?
+            LIMIT 1
+        ");
+        $stmt->execute([$domainId, $type, $expirationDate]);
+
+        return (bool)$stmt->fetchColumn();
+    }
+
+    public function storeErrpNotification(array $data): void
+    {
+        $stmt = $this->pdo->prepare("
+            INSERT INTO domain_registrar_notification
+                (domain_id, domain, type, recipient, subject, body, metadata, sent_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        ");
+
+        $stmt->execute([
+            $data['domain_id'],
+            $data['domain'],
+            $data['type'],
+            $data['recipient'],
+            $data['subject'],
+            $data['body'],
+            json_encode(
+                $data['metadata'],
+                JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
+            ),
+            $data['sent_at'],
+        ]);
     }
 
     public function getExpiredDomains(): array

--- a/automation/src/Backend/LOOM.php
+++ b/automation/src/Backend/LOOM.php
@@ -642,7 +642,8 @@ final class LOOM extends AbstractDriver
     public function getErrpDomains(): array
     {
         $stmt = $this->pdo->prepare("
-            SELECT service_name AS domain_name,
+            SELECT id AS domain_id,
+                   service_name AS domain_name,
                    expires_at,
                    JSON_UNQUOTE(JSON_EXTRACT(config, '$.contacts.registrant.email')) AS email
             FROM services
@@ -654,6 +655,48 @@ final class LOOM extends AbstractDriver
         $stmt->execute();
 
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    public function hasErrpNotification(
+        int $domainId,
+        string $type,
+        string $expirationDate
+    ): bool
+    {
+        $stmt = $this->pdo->prepare("
+            SELECT 1
+            FROM domain_registrar_notification
+            WHERE domain_id = ?
+              AND type = ?
+              AND JSON_UNQUOTE(JSON_EXTRACT(metadata, '$.expires_at')) = ?
+            LIMIT 1
+        ");
+        $stmt->execute([$domainId, $type, $expirationDate]);
+
+        return (bool)$stmt->fetchColumn();
+    }
+
+    public function storeErrpNotification(array $data): void
+    {
+        $stmt = $this->pdo->prepare("
+            INSERT INTO domain_registrar_notification
+                (domain_id, domain, type, recipient, subject, body, metadata, sent_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        ");
+
+        $stmt->execute([
+            $data['domain_id'],
+            $data['domain'],
+            $data['type'],
+            $data['recipient'],
+            $data['subject'],
+            $data['body'],
+            json_encode(
+                $data['metadata'],
+                JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
+            ),
+            $data['sent_at'],
+        ]);
     }
 
     public function getExpiredDomains(): array

--- a/automation/src/Backend/WHMCS.php
+++ b/automation/src/Backend/WHMCS.php
@@ -605,18 +605,65 @@ final class WHMCS extends AbstractDriver
     public function getErrpDomains(): array
     {
         $stmt = $this->pdo->prepare("
-            SELECT nd.name AS domain_name,
+            SELECT nd.id AS domain_id,
+                   nd.name AS domain_name,
                    nd.exdate AS expires_at,
-                   c.email
+                   COALESCE(NULLIF(tc.email, ''), c.email) AS email
             FROM namingo_domain nd
             INNER JOIN tbldomains d ON d.domain = nd.name
             INNER JOIN tblclients c ON c.id = d.userid
+            LEFT JOIN tblorders o ON o.id = d.orderid
+            LEFT JOIN tblcontacts tc
+                ON tc.id = o.contactid
+               AND tc.userid = d.userid
             WHERE DATE(nd.exdate) BETWEEN DATE_SUB(CURDATE(), INTERVAL 5 DAY)
                                       AND DATE_ADD(CURDATE(), INTERVAL 30 DAY)
         ");
         $stmt->execute();
 
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    public function hasErrpNotification(
+        int $domainId,
+        string $type,
+        string $expirationDate
+    ): bool
+    {
+        $stmt = $this->pdo->prepare("
+            SELECT 1
+            FROM namingo_registrar_notifications
+            WHERE domain_id = ?
+              AND type = ?
+              AND JSON_UNQUOTE(JSON_EXTRACT(metadata, '$.expires_at')) = ?
+            LIMIT 1
+        ");
+        $stmt->execute([$domainId, $type, $expirationDate]);
+
+        return (bool)$stmt->fetchColumn();
+    }
+
+    public function storeErrpNotification(array $data): void
+    {
+        $stmt = $this->pdo->prepare("
+            INSERT INTO namingo_registrar_notifications
+                (domain_id, domain, type, recipient, subject, body, metadata, sent_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        ");
+
+        $stmt->execute([
+            $data['domain_id'],
+            $data['domain'],
+            $data['type'],
+            $data['recipient'],
+            $data['subject'],
+            $data['body'],
+            json_encode(
+                $data['metadata'],
+                JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
+            ),
+            $data['sent_at'],
+        ]);
     }
 
     public function getExpiredDomains(): array


### PR DESCRIPTION
## Summary

- send WHMCS ERRP notices to the order contact when present, falling back to the client account email
- retain successful ERRP notices in the existing registrar notification table
- deduplicate by domain, notice type, and expiration date
- add bounded catch-up windows for the required renewal and post-expiration notices

No schema changes or additional tables are required.