### PR TITLE
Make ERRP DNS interruption stateful and restorable

### DIFF
--- a/automation/config.php.dist
+++ b/automation/config.php.dist
@@ -63,6 +63,21 @@ $config = array(
     'ssl_cafile' => '/path/to/ssl/cafile', // Or leave empty ''
     'ns1' => 'ns1.registrar.com',
     'ns2' => 'ns2.registrar.com',
+
+    // Expired Registration Recovery Policy DNS interruption
+    'errp' => array(
+        // These nameservers must interrupt the RAE's existing DNS path. If
+        // they serve a web page, it must conspicuously say that the domain is
+        // expired and provide renewal instructions (ICANN ERRP 2.2.4).
+        // Falls back to the legacy ns1/ns2 values above when left empty.
+        'nameservers' => array(),
+
+        // Optional explicit ICANN gTLD allowlist, without leading dots.
+        // When empty, WHMCS uses its "gTLD Registry" setting and FOSSBilling
+        // uses "Enable Minimum Data Set". Configure this list for LOOM,
+        // custom drivers, or whenever an explicit policy scope is preferred.
+        'tlds' => array(),
+    ),
     'registrar_url' => 'https://example.com/',
     'registrar_name' => 'Example Registrar LLC',
 

--- a/automation/cron.php
+++ b/automation/cron.php
@@ -56,7 +56,7 @@ if ($cronJobConfig['tools']) {
     $addJob('wdrp', $php . ' /opt/registrar/automation/wdrp.php', '0 0 * * *');
     $addJob('validation', $php . ' /opt/registrar/automation/validation.php', '*/15 * * * *');
     $addJob('errp-notify', $php . ' /opt/registrar/automation/errp_notify.php', '0 1 * * *');
-    $addJob('errp-dns', $php . ' /opt/registrar/automation/errp_dns.php', '0 2 * * *');
+    $addJob('errp-dns', $php . ' /opt/registrar/automation/errp_dns.php', '*/5 * * * *');
     $addJob('urs-keyring', $php . ' /opt/registrar/automation/urs_keyring.php', '15 0 * * *');
     $addJob('urs', $php . ' /opt/registrar/automation/urs.php', '45 * * * *');
 }

--- a/automation/errp_dns.php
+++ b/automation/errp_dns.php
@@ -2,6 +2,8 @@
 /**
  * Namingo Registrar
  *
+ * Stateful ICANN ERRP DNS interruption and renewal restoration processor.
+ *
  * Written in 2023-2026 by Taras Kondratyuk (https://namingo.org/)
  *
  * @license MIT
@@ -10,6 +12,7 @@
 declare(strict_types=1);
 
 use Registrar\Backend\DriverFactory;
+use Registrar\Backend\DriverInterface;
 
 date_default_timezone_set('UTC');
 
@@ -17,57 +20,663 @@ require_once __DIR__ . '/config.php';
 require_once __DIR__ . '/helpers.php';
 require_once __DIR__ . '/vendor/autoload.php';
 
-$logFilePath = '/var/log/namingo/errp_dns.log';
-$log = setupLogger($logFilePath, 'ERRP_DNS');
+$log = setupLogger('/var/log/namingo/errp_dns.log', 'ERRP_DNS');
 $log->info('job started.');
 
 try {
-    $pdo = new PDO("mysql:host={$config['db']['host']};dbname={$config['db']['dbname']}", $config['db']['username'], $config['db']['password']);
+    $pdo = new PDO(
+        "mysql:host={$config['db']['host']};dbname={$config['db']['dbname']}",
+        $config['db']['username'],
+        $config['db']['password']
+    );
     $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
     $driver = DriverFactory::create($pdo, $config, $log);
+} catch (Throwable $e) {
+    $log->error('Initialization error: ' . $e->getMessage());
+    exit(1);
+}
 
-    $expired_domains = $driver->getExpiredDomains();
+function errpDnsNow(): string
+{
+    return gmdate('Y-m-d\\TH:i:s\\Z');
+}
 
-    foreach ($expired_domains as $domain) {
-        $ns1 = $config['ns1'];
-        $ns2 = $config['ns2'];
-        $domainName = $domain['domain_name'];
+function errpDnsDate(string $value): DateTimeImmutable
+{
+    if (trim($value) === '') {
+        throw new InvalidArgumentException('Empty domain expiration date.');
+    }
 
-        $driver->updateExpiredDomainNameservers($domain, $ns1, $ns2);
-        $eppConfig = $driver->getEppConfiguration($domainName);
+    return (new DateTimeImmutable($value))->setTimezone(new DateTimeZone('UTC'));
+}
 
-        try {
-            $epp = epp_client($eppConfig);
-            $domainPuny = function_exists('idn_to_ascii')
-                ? (idn_to_ascii($domainName, IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46) ?: $domainName)
-                : $domainName;
+function errpDnsAscii(string $value): string
+{
+    $value = strtolower(rtrim(trim($value), '.'));
 
-            $params = array(
-                'domainname' => $domainPuny,
-                'ns1' => $ns1,
-                'ns2' => $ns2
-            );
-            $domainUpdateNS = $epp->domainUpdateNS($params);
+    if ($value !== '' && function_exists('idn_to_ascii')) {
+        $ascii = idn_to_ascii(
+            $value,
+            IDNA_DEFAULT,
+            INTL_IDNA_VARIANT_UTS46
+        );
 
-            if (array_key_exists('error', $domainUpdateNS)) {
-                $log->error($domainUpdateNS['error'] . ' (' . $domainName . ')');
-            } else {
-                $log->info('job completed.');
-            }
-        } catch(EppException $e) {
-            $log->error('Error: ' . $e->getMessage());
-            exit(1);
-        } finally {
-            epp_client_logout($epp);
+        if (is_string($ascii) && $ascii !== '') {
+            return strtolower($ascii);
         }
     }
-} catch (PDOException $e) {
-    $log->error('Database error: ' . $e->getMessage());
-    exit(1);
-} catch (Exception $e) {
-    $log->error('Error: ' . $e->getMessage());
-    exit(1);
+
+    return $value;
+}
+
+function errpDnsNameservers(mixed $values): array
+{
+    $values = is_array($values) ? $values : [$values];
+    $result = [];
+
+    foreach ($values as $value) {
+        if (is_array($value)) {
+            $value = $value['hostName']
+                ?? $value['hostname']
+                ?? $value['host']
+                ?? $value['name']
+                ?? '';
+        }
+
+        if (!is_scalar($value)) {
+            continue;
+        }
+
+        $nameserver = errpDnsAscii((string)$value);
+
+        if ($nameserver !== '' && !in_array($nameserver, $result, true)) {
+            $result[] = $nameserver;
+        }
+    }
+
+    return array_slice($result, 0, 9);
+}
+
+function errpDnsSameNameservers(array $first, array $second): bool
+{
+    $first = errpDnsNameservers($first);
+    $second = errpDnsNameservers($second);
+    sort($first);
+    sort($second);
+
+    return $first === $second;
+}
+
+function errpDnsInterruptionNameservers(array $config): array
+{
+    $configured = $config['errp']['nameservers'] ?? [];
+
+    if (!is_array($configured) || $configured === []) {
+        $configured = [$config['ns1'] ?? '', $config['ns2'] ?? ''];
+    }
+
+    $nameservers = errpDnsNameservers($configured);
+
+    if (count($nameservers) < 2) {
+        throw new RuntimeException(
+            'At least two ERRP interruption nameservers must be configured.'
+        );
+    }
+
+    foreach ($nameservers as $nameserver) {
+        if (!filter_var(
+            $nameserver,
+            FILTER_VALIDATE_DOMAIN,
+            FILTER_FLAG_HOSTNAME
+        )) {
+            throw new RuntimeException(
+                "Invalid ERRP interruption nameserver: {$nameserver}"
+            );
+        }
+    }
+
+    return $nameservers;
+}
+
+function errpDnsTld(string $domain): string
+{
+    $labels = explode('.', errpDnsAscii($domain));
+
+    return (string)end($labels);
+}
+
+function errpDnsConfiguredTlds(array $config): array
+{
+    $tlds = $config['errp']['tlds'] ?? [];
+
+    if (is_string($tlds)) {
+        $tlds = preg_split('/[\s,]+/', $tlds) ?: [];
+    }
+
+    return is_array($tlds)
+        ? array_values(array_unique(array_filter(array_map(
+            static fn ($tld): string => errpDnsAscii(ltrim((string)$tld, '.')),
+            $tlds
+        ))))
+        : [];
+}
+
+function errpDnsTrue(mixed $value): bool
+{
+    return $value === true
+        || $value === 1
+        || in_array(
+            strtolower(trim((string)$value)),
+            ['1', 'true', 'yes', 'on', 'enabled'],
+            true
+        );
+}
+
+function errpDnsEligible(
+    string $domain,
+    array $eppConfig,
+    array $config
+): bool {
+    $configuredTlds = errpDnsConfiguredTlds($config);
+
+    if ($configuredTlds !== []) {
+        return in_array(errpDnsTld($domain), $configuredTlds, true);
+    }
+
+    $registryConfig = $eppConfig['config'] ?? [];
+
+    if (!is_array($registryConfig)) {
+        return false;
+    }
+
+    foreach (['gtld', 'is_gtld', 'g_tld', 'min_data_set'] as $key) {
+        if (array_key_exists($key, $registryConfig)) {
+            return errpDnsTrue($registryConfig[$key]);
+        }
+    }
+
+    return false;
+}
+
+function errpDnsEppError(mixed $response, bool $emptyIsSuccess): ?string
+{
+    if (!is_array($response)) {
+        return 'Unexpected non-array EPP response.';
+    }
+
+    if ($response === []) {
+        return $emptyIsSuccess ? null : 'Empty EPP response.';
+    }
+
+    if (trim((string)($response['error'] ?? '')) !== '') {
+        return (string)$response['error'];
+    }
+
+    if (!array_key_exists('code', $response)) {
+        return 'EPP response did not include a result code.';
+    }
+
+    if ((int)$response['code'] !== 1000) {
+        return 'EPP ' . (int)$response['code'] . ': '
+            . (string)($response['msg'] ?? 'command was not completed');
+    }
+
+    return null;
+}
+
+function errpDnsEppParams(string $domain, array $nameservers): array
+{
+    $params = ['domainname' => errpDnsAscii($domain)];
+
+    foreach (errpDnsNameservers($nameservers) as $index => $nameserver) {
+        $params['ns' . ($index + 1)] = $nameserver;
+    }
+
+    return $params;
+}
+
+function errpDnsDomainInfo(string $domain, array $eppConfig): array
+{
+    $epp = null;
+
+    try {
+        $epp = epp_client($eppConfig);
+        $response = $epp->domainInfo([
+            'domainname' => errpDnsAscii($domain),
+        ]);
+        $error = errpDnsEppError($response, false);
+
+        if ($error !== null) {
+            throw new RuntimeException($error);
+        }
+
+        return $response;
+    } finally {
+        epp_client_logout($epp);
+    }
+}
+
+function errpDnsChangeRegistry(
+    string $domain,
+    array $nameservers,
+    array $eppConfig
+): void {
+    $epp = null;
+
+    try {
+        $epp = epp_client($eppConfig);
+        $response = $epp->domainUpdateNS(
+            errpDnsEppParams($domain, $nameservers)
+        );
+        $error = errpDnsEppError($response, true);
+
+        if ($error !== null) {
+            throw new RuntimeException($error);
+        }
+    } finally {
+        epp_client_logout($epp);
+    }
+}
+
+function errpDnsRegistryNameservers(array $domainInfo): array
+{
+    foreach (['ns', 'nameservers', 'nss'] as $key) {
+        if (array_key_exists($key, $domainInfo)) {
+            return errpDnsNameservers($domainInfo[$key]);
+        }
+    }
+
+    return [];
+}
+
+function errpDnsRegistryStatuses(array $domainInfo): array
+{
+    $statuses = $domainInfo['status'] ?? [];
+    $statuses = is_array($statuses) ? $statuses : [$statuses];
+    $result = [];
+
+    foreach ($statuses as $status) {
+        if (is_array($status)) {
+            $status = $status['s']
+                ?? $status['status']
+                ?? $status['value']
+                ?? '';
+        }
+
+        if (is_scalar($status) && trim((string)$status) !== '') {
+            $result[] = trim((string)$status);
+        }
+    }
+
+    return array_values(array_unique($result));
+}
+
+function errpDnsTerminalStatus(array $statuses): ?string
+{
+    foreach ($statuses as $status) {
+        $statusKey = strtolower((string)preg_replace('/[^a-z]/i', '', $status));
+
+        if (in_array($statusKey, ['pendingdelete', 'redemptionperiod'], true)) {
+            return $status;
+        }
+    }
+
+    return null;
+}
+
+function errpDnsMetadata(array $row): array
+{
+    $metadata = json_decode(
+        (string)($row['metadata'] ?? ''),
+        true,
+        512,
+        JSON_THROW_ON_ERROR
+    );
+
+    if (!is_array($metadata)) {
+        throw new RuntimeException('ERRP DNS state metadata is invalid.');
+    }
+
+    return $metadata;
+}
+
+function errpDnsSave(
+    DriverInterface $driver,
+    int $stateId,
+    array &$metadata,
+    string $state,
+    ?Throwable $error = null,
+    ?string $operation = null
+): void {
+    $metadata['state'] = $state;
+    $metadata['updated_at'] = errpDnsNow();
+    $metadata['last_error'] = $error?->getMessage();
+    $metadata['last_error_at'] = $error === null ? null : errpDnsNow();
+    $metadata['last_failed_operation'] = $error === null ? null : $operation;
+    $driver->updateErrpDnsState($stateId, $metadata);
+}
+
+function errpDnsInterrupt(
+    DriverInterface $driver,
+    array $domain,
+    int $stateId,
+    array &$metadata,
+    object $log
+): void {
+    $domainName = (string)$domain['domain_name'];
+    $nameservers = errpDnsNameservers(
+        $metadata['interruption_nameservers'] ?? []
+    );
+    $metadata['attempts']['interrupt'] =
+        (int)($metadata['attempts']['interrupt'] ?? 0) + 1;
+
+    try {
+        $eppConfig = $driver->getEppConfiguration($domainName);
+        errpDnsChangeRegistry($domainName, $nameservers, $eppConfig);
+
+        // Local state changes only after the registry confirms the update.
+        $driver->updateErrpDomainNameservers($domain, $nameservers);
+        $metadata['interrupted_at'] = errpDnsNow();
+        errpDnsSave($driver, $stateId, $metadata, 'interrupted');
+        $log->info("ERRP DNS resolution interrupted for {$domainName}.");
+    } catch (Throwable $e) {
+        errpDnsSave(
+            $driver,
+            $stateId,
+            $metadata,
+            'pending',
+            $e,
+            'interrupt'
+        );
+        throw $e;
+    }
+}
+
+function errpDnsRestore(
+    DriverInterface $driver,
+    array $domain,
+    int $stateId,
+    array &$metadata,
+    object $log
+): void {
+    $domainName = (string)$domain['domain_name'];
+    $registryNameservers = errpDnsNameservers(
+        $metadata['original_registry_nameservers'] ?? []
+    );
+    $localNameservers = errpDnsNameservers(
+        $metadata['original_local_nameservers'] ?? []
+    );
+    $localNameservers = $localNameservers ?: $registryNameservers;
+    $metadata['attempts']['restore'] =
+        (int)($metadata['attempts']['restore'] ?? 0) + 1;
+
+    try {
+        if (count($registryNameservers) < 1) {
+            throw new RuntimeException(
+                'Original registry nameservers are unavailable; automatic restoration is unsafe.'
+            );
+        }
+
+        $eppConfig = $driver->getEppConfiguration($domainName);
+        errpDnsChangeRegistry(
+            $domainName,
+            $registryNameservers,
+            $eppConfig
+        );
+        $driver->updateErrpDomainNameservers($domain, $localNameservers);
+        $metadata['restored_at'] = errpDnsNow();
+        errpDnsSave($driver, $stateId, $metadata, 'restored');
+        $log->info("ERRP DNS resolution restored after renewal for {$domainName}.");
+    } catch (Throwable $e) {
+        errpDnsSave(
+            $driver,
+            $stateId,
+            $metadata,
+            (string)($metadata['state'] ?? 'pending'),
+            $e,
+            'restore'
+        );
+        throw $e;
+    }
+}
+
+function errpDnsRenewed(array $domain, array $metadata): bool
+{
+    $original = errpDnsDate((string)($metadata['expires_at'] ?? ''));
+    $current = errpDnsDate((string)($domain['expires_at'] ?? ''));
+
+    return $current > $original
+        && $current > new DateTimeImmutable('now', new DateTimeZone('UTC'));
+}
+
+function errpDnsProcessStates(
+    DriverInterface $driver,
+    object $log
+): void {
+    $afterId = 0;
+    $batchSize = 500;
+
+    do {
+        $states = $driver->getActiveErrpDnsStates($batchSize, $afterId);
+
+        foreach ($states as $stateRow) {
+            $stateId = (int)($stateRow['id'] ?? 0);
+            $afterId = max($afterId, $stateId);
+
+            try {
+                $metadata = errpDnsMetadata($stateRow);
+                $domain = $driver->getErrpDnsDomain(
+                    (int)($stateRow['domain_id'] ?? 0)
+                );
+
+                if ($domain === null) {
+                    throw new RuntimeException(
+                        'Local domain no longer exists; restoration state retained.'
+                    );
+                }
+
+                if (errpDnsRenewed($domain, $metadata)) {
+                    errpDnsRestore(
+                        $driver,
+                        $domain,
+                        $stateId,
+                        $metadata,
+                        $log
+                    );
+                } elseif (
+                    !empty($domain['errp_active'])
+                    && (string)($metadata['state'] ?? '') === 'pending'
+                ) {
+                    errpDnsInterrupt(
+                        $driver,
+                        $domain,
+                        $stateId,
+                        $metadata,
+                        $log
+                    );
+                }
+            } catch (Throwable $e) {
+                $log->error(
+                    "ERRP DNS state {$stateId} failed: " . $e->getMessage()
+                );
+            }
+        }
+    } while (count($states) === $batchSize);
+}
+
+function errpDnsDiscover(
+    DriverInterface $driver,
+    array $interruptionNameservers,
+    array $config,
+    object $log
+): void {
+    $afterId = 0;
+    $batchSize = 500;
+    $warnedTlds = [];
+
+    do {
+        $domains = $driver->getExpiredDomains($batchSize, $afterId);
+
+        foreach ($domains as $domain) {
+            $domainId = (int)($domain['id'] ?? 0);
+            $afterId = max($afterId, $domainId);
+            $domainName = strtolower(rtrim(
+                trim((string)($domain['domain_name'] ?? '')),
+                '.'
+            ));
+
+            try {
+                if ($domainId < 1 || $domainName === '') {
+                    throw new RuntimeException('Malformed expired-domain row.');
+                }
+
+                $expiration = errpDnsDate(
+                    (string)($domain['expires_at'] ?? '')
+                )->format('Y-m-d H:i:s');
+
+                if ($driver->findErrpDnsState($domainId, $expiration) !== null) {
+                    continue;
+                }
+
+                $configuredTlds = errpDnsConfiguredTlds($config);
+
+                if (
+                    $configuredTlds !== []
+                    && !in_array(errpDnsTld($domainName), $configuredTlds, true)
+                ) {
+                    continue;
+                }
+
+                $eppConfig = $driver->getEppConfiguration($domainName);
+
+                if (!errpDnsEligible($domainName, $eppConfig, $config)) {
+                    $tld = errpDnsTld($domainName);
+
+                    if (!isset($warnedTlds[$tld])) {
+                        $warnedTlds[$tld] = true;
+                        $log->info(
+                            "Skipping .{$tld}: not configured as an ICANN gTLD for ERRP."
+                        );
+                    }
+                    continue;
+                }
+
+                $domainInfo = errpDnsDomainInfo($domainName, $eppConfig);
+                $registryNameservers = errpDnsRegistryNameservers($domainInfo);
+                $localNameservers = errpDnsNameservers(
+                    $domain['nameservers'] ?? []
+                );
+                $originalLocalNameservers = $localNameservers;
+                $snapshotSource = 'registry';
+
+                if (
+                    errpDnsSameNameservers(
+                        $registryNameservers,
+                        $interruptionNameservers
+                    )
+                    && !errpDnsSameNameservers(
+                        $localNameservers,
+                        $interruptionNameservers
+                    )
+                    && count($localNameservers) >= 1
+                ) {
+                    $registryNameservers = $localNameservers;
+                    $snapshotSource = 'local_fallback';
+                } elseif (
+                    errpDnsSameNameservers(
+                        $localNameservers,
+                        $interruptionNameservers
+                    )
+                    && !errpDnsSameNameservers(
+                        $registryNameservers,
+                        $interruptionNameservers
+                    )
+                    && count($registryNameservers) >= 1
+                ) {
+                    // Repair snapshots produced after the legacy job changed
+                    // local data but failed before changing the registry.
+                    $originalLocalNameservers = $registryNameservers;
+                    $snapshotSource = 'registry_local_repair';
+                }
+
+                $statuses = errpDnsRegistryStatuses($domainInfo);
+                $terminalStatus = errpDnsTerminalStatus($statuses);
+                $metadata = [
+                    'policy' => 'ICANN ERRP 2.2.2-2.2.6',
+                    'state' => 'pending',
+                    'tld' => errpDnsTld($domainName),
+                    'expires_at' => $expiration,
+                    'original_registry_nameservers' => $registryNameservers,
+                    'original_local_nameservers' => $originalLocalNameservers,
+                    'interruption_nameservers' => $interruptionNameservers,
+                    'registry_statuses' => $statuses,
+                    'snapshot_source' => $snapshotSource,
+                    'attempts' => [],
+                    'created_at' => errpDnsNow(),
+                    'updated_at' => errpDnsNow(),
+                    'last_error' => null,
+                ];
+
+                if ($terminalStatus !== null) {
+                    $metadata['state'] = 'not_applicable';
+                    $metadata['closed_reason'] =
+                        'terminal_registry_status:' . $terminalStatus;
+                } elseif (count($registryNameservers) < 1) {
+                    $metadata['state'] = 'not_applicable';
+                    $metadata['closed_reason'] =
+                        'original_registry_nameservers_unavailable';
+                } elseif (
+                    errpDnsSameNameservers(
+                        $registryNameservers,
+                        $interruptionNameservers
+                    )
+                ) {
+                    $metadata['state'] = 'not_applicable';
+                    $metadata['closed_reason'] =
+                        'already_interrupted_without_original_snapshot';
+                }
+
+                // The original registry and local paths are durable before
+                // any EPP or local nameserver update is attempted.
+                $stateId = $driver->storeErrpDnsState([
+                    'domain_id' => $domainId,
+                    'domain' => $domainName,
+                    'metadata' => $metadata,
+                    'sent_at' => gmdate('Y-m-d H:i:s'),
+                ]);
+
+                if ($metadata['state'] === 'pending') {
+                    errpDnsInterrupt(
+                        $driver,
+                        $domain,
+                        $stateId,
+                        $metadata,
+                        $log
+                    );
+                } else {
+                    $log->warning(
+                        "ERRP DNS state not applied for {$domainName}: "
+                        . $metadata['closed_reason']
+                    );
+                }
+            } catch (Throwable $e) {
+                $log->error(
+                    "ERRP DNS discovery failed for {$domainName}: "
+                    . $e->getMessage()
+                );
+            }
+        }
+    } while (count($domains) === $batchSize);
+}
+
+try {
+    $interruptionNameservers = errpDnsInterruptionNameservers($config);
+
+    // Restorations are checked first to minimize post-renewal downtime.
+    errpDnsProcessStates($driver, $log);
+    errpDnsDiscover($driver, $interruptionNameservers, $config, $log);
+    $log->info('job completed.');
 } catch (Throwable $e) {
-    $log->error('Error: ' . $e->getMessage());
+    $log->error('Fatal ERRP DNS error: ' . $e->getMessage());
     exit(1);
 }

--- a/automation/src/Backend/AbstractDriver.php
+++ b/automation/src/Backend/AbstractDriver.php
@@ -130,6 +130,148 @@ abstract class AbstractDriver implements DriverInterface
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
     }
 
+    public function findErrpDnsState(
+        int $domainId,
+        string $expirationDate
+    ): ?array {
+        $table = $this->notificationTable();
+        $stmt = $this->pdo->prepare("
+            SELECT id, domain_id, domain, metadata, sent_at, created_at
+            FROM {$table}
+            WHERE type = 'errp_dns'
+              AND domain_id = :domain_id
+              AND JSON_UNQUOTE(JSON_EXTRACT(metadata, '$.expires_at')) = :expires_at
+            ORDER BY id DESC
+            LIMIT 1
+        ");
+        $stmt->execute([
+            'domain_id' => $domainId,
+            'expires_at' => $expirationDate,
+        ]);
+
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        return $row ?: null;
+    }
+
+    public function storeErrpDnsState(array $data): int
+    {
+        $table = $this->notificationTable();
+        $metadata = $data['metadata'];
+        $expirationDate = (string)($metadata['expires_at'] ?? '');
+
+        if ($expirationDate === '') {
+            throw new \InvalidArgumentException(
+                'ERRP DNS state requires an expiration date.'
+            );
+        }
+
+        $stmt = $this->pdo->prepare("
+            INSERT INTO {$table} (
+                domain_id,
+                domain,
+                type,
+                recipient,
+                subject,
+                body,
+                metadata,
+                sent_at
+            )
+            SELECT
+                :domain_id,
+                :domain,
+                'errp_dns',
+                '',
+                'ERRP DNS lifecycle state',
+                '',
+                :metadata,
+                :sent_at
+            WHERE NOT EXISTS (
+                SELECT 1
+                FROM {$table}
+                WHERE type = 'errp_dns'
+                  AND domain_id = :existing_domain_id
+                  AND JSON_UNQUOTE(
+                        JSON_EXTRACT(metadata, '$.expires_at')
+                      ) = :existing_expires_at
+            )
+        ");
+        $stmt->execute([
+            'domain_id' => (int)$data['domain_id'],
+            'domain' => (string)$data['domain'],
+            'metadata' => json_encode(
+                $metadata,
+                JSON_UNESCAPED_SLASHES
+                | JSON_UNESCAPED_UNICODE
+                | JSON_THROW_ON_ERROR
+            ),
+            'sent_at' => (string)$data['sent_at'],
+            'existing_domain_id' => (int)$data['domain_id'],
+            'existing_expires_at' => $expirationDate,
+        ]);
+
+        if ($stmt->rowCount() > 0) {
+            return (int)$this->pdo->lastInsertId();
+        }
+
+        $existing = $this->findErrpDnsState(
+            (int)$data['domain_id'],
+            $expirationDate
+        );
+
+        if ($existing === null) {
+            throw new \RuntimeException('Unable to create or find ERRP DNS state.');
+        }
+
+        return (int)$existing['id'];
+    }
+
+    public function getActiveErrpDnsStates(
+        int $limit = 500,
+        int $afterId = 0
+    ): array
+    {
+        $table = $this->notificationTable();
+        $limit = max(1, min($limit, 1000));
+        $stmt = $this->pdo->prepare("
+            SELECT id, domain_id, domain, metadata, sent_at, created_at
+            FROM {$table}
+            WHERE type = 'errp_dns'
+              AND id > :after_id
+              AND COALESCE(
+                    JSON_UNQUOTE(JSON_EXTRACT(metadata, '$.state')),
+                    ''
+                  ) NOT IN ('restored', 'closed', 'not_applicable')
+            ORDER BY id ASC
+            LIMIT :limit
+        ");
+        $stmt->bindValue(':after_id', max(0, $afterId), PDO::PARAM_INT);
+        $stmt->bindValue(':limit', $limit, PDO::PARAM_INT);
+        $stmt->execute();
+
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    public function updateErrpDnsState(int $id, array $metadata): void
+    {
+        $table = $this->notificationTable();
+        $stmt = $this->pdo->prepare("
+            UPDATE {$table}
+            SET metadata = :metadata
+            WHERE id = :id
+              AND type = 'errp_dns'
+        ");
+        $stmt->execute([
+            'metadata' => json_encode(
+                $metadata,
+                JSON_UNESCAPED_SLASHES
+                | JSON_UNESCAPED_UNICODE
+                | JSON_THROW_ON_ERROR
+            ),
+            'id' => $id,
+        ]);
+    }
+
     protected function notificationTable(): string
     {
         return 'registrar_notifications';

--- a/automation/src/Backend/Custom.php
+++ b/automation/src/Backend/Custom.php
@@ -17,7 +17,7 @@ use RuntimeException;
  * - validation rows: every active, unexpired domain with domain_name,
  *   registrant_email, validation, registered_at, verification_key and
  *   contact_data/registrant_data arrays used for exact hashing
- * - expired domains: domain_name plus any backend keys needed by the update
+ * - expired domains: id, domain_name, expires_at, nameservers and errp_active
  */
 class Custom extends AbstractDriver
 {
@@ -100,12 +100,23 @@ class Custom extends AbstractDriver
         throw $this->notImplemented(__FUNCTION__);
     }
 
-    public function getExpiredDomains(): array
+    public function getExpiredDomains(
+        int $limit = 500,
+        int $afterId = 0
+    ): array
     {
         throw $this->notImplemented(__FUNCTION__);
     }
 
-    public function updateExpiredDomainNameservers(array $row, string $ns1, string $ns2): void
+    public function getErrpDnsDomain(int $domainId): ?array
+    {
+        throw $this->notImplemented(__FUNCTION__);
+    }
+
+    public function updateErrpDomainNameservers(
+        array $row,
+        array $nameservers
+    ): void
     {
         throw $this->notImplemented(__FUNCTION__);
     }

--- a/automation/src/Backend/DriverInterface.php
+++ b/automation/src/Backend/DriverInterface.php
@@ -54,7 +54,29 @@ interface DriverInterface
 
     public function storeErrpNotification(array $data): void;
 
-    public function getExpiredDomains(): array;
+    public function findErrpDnsState(
+        int $domainId,
+        string $expirationDate
+    ): ?array;
 
-    public function updateExpiredDomainNameservers(array $row, string $ns1, string $ns2): void;
+    public function storeErrpDnsState(array $data): int;
+
+    public function getActiveErrpDnsStates(
+        int $limit = 500,
+        int $afterId = 0
+    ): array;
+
+    public function updateErrpDnsState(int $id, array $metadata): void;
+
+    public function getExpiredDomains(
+        int $limit = 500,
+        int $afterId = 0
+    ): array;
+
+    public function getErrpDnsDomain(int $domainId): ?array;
+
+    public function updateErrpDomainNameservers(
+        array $row,
+        array $nameservers
+    ): void;
 }

--- a/automation/src/Backend/FOSS.php
+++ b/automation/src/Backend/FOSS.php
@@ -759,18 +759,88 @@ final class FOSS extends AbstractDriver
         ]);
     }
 
-    public function getExpiredDomains(): array
+    public function getExpiredDomains(
+        int $limit = 500,
+        int $afterId = 0
+    ): array
     {
-        $stmt = $this->pdo->prepare("SELECT * FROM service_domain WHERE NOW() > expires_at");
+        $limit = max(1, min($limit, 1000));
+        $stmt = $this->pdo->prepare("
+            SELECT sd.*
+            FROM service_domain sd
+            WHERE NOW() > sd.expires_at
+              AND sd.id > :after_id
+              AND sd.registered_at IS NOT NULL
+              AND EXISTS (
+                    SELECT 1
+                    FROM client_order co
+                    WHERE co.service_id = sd.id
+                      AND co.service_type = 'domain'
+                      AND co.status = 'active'
+              )
+            ORDER BY sd.id ASC
+            LIMIT :limit
+        ");
+        $stmt->bindValue(':after_id', max(0, $afterId), PDO::PARAM_INT);
+        $stmt->bindValue(':limit', $limit, PDO::PARAM_INT);
         $stmt->execute();
         $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
         foreach ($rows as &$row) {
             $row['domain_name'] = $this->buildDomainName($row);
+            $row['nameservers'] = array_values(array_filter([
+                $row['ns1'] ?? null,
+                $row['ns2'] ?? null,
+                $row['ns3'] ?? null,
+                $row['ns4'] ?? null,
+            ], static fn ($value): bool => trim((string)$value) !== ''));
+            $row['errp_active'] = true;
         }
         unset($row);
 
         return $rows;
+    }
+
+    public function getErrpDnsDomain(int $domainId): ?array
+    {
+        $stmt = $this->pdo->prepare("
+            SELECT sd.*,
+                   COALESCE((
+                       SELECT co.status
+                       FROM client_order co
+                       WHERE co.service_id = sd.id
+                         AND co.service_type = 'domain'
+                       ORDER BY co.id DESC
+                       LIMIT 1
+                   ), '') AS billing_status,
+                   EXISTS (
+                       SELECT 1
+                       FROM client_order active_order
+                       WHERE active_order.service_id = sd.id
+                         AND active_order.service_type = 'domain'
+                         AND active_order.status = 'active'
+                   ) AS errp_active
+            FROM service_domain sd
+            WHERE sd.id = :id
+            LIMIT 1
+        ");
+        $stmt->execute(['id' => $domainId]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        if (!$row) {
+            return null;
+        }
+
+        $row['domain_name'] = $this->buildDomainName($row);
+        $row['nameservers'] = array_values(array_filter([
+            $row['ns1'] ?? null,
+            $row['ns2'] ?? null,
+            $row['ns3'] ?? null,
+            $row['ns4'] ?? null,
+        ], static fn ($value): bool => trim((string)$value) !== ''));
+        $row['errp_active'] = (bool)$row['errp_active'];
+
+        return $row;
     }
 
     private function buildDomainName(array $row): string
@@ -781,12 +851,29 @@ final class FOSS extends AbstractDriver
         return $sld . (str_starts_with($tld, '.') ? $tld : '.' . $tld);
     }
 
-    public function updateExpiredDomainNameservers(array $row, string $ns1, string $ns2): void
+    public function updateErrpDomainNameservers(
+        array $row,
+        array $nameservers
+    ): void
     {
-        $stmt = $this->pdo->prepare("UPDATE service_domain SET ns1 = :ns1, ns2 = :ns2 WHERE id = :id");
+        $nameservers = array_pad(
+            array_slice(array_values($nameservers), 0, 4),
+            4,
+            null
+        );
+        $stmt = $this->pdo->prepare("
+            UPDATE service_domain
+            SET ns1 = :ns1,
+                ns2 = :ns2,
+                ns3 = :ns3,
+                ns4 = :ns4
+            WHERE id = :id
+        ");
         $stmt->execute([
-            'ns1' => $ns1,
-            'ns2' => $ns2,
+            'ns1' => $nameservers[0],
+            'ns2' => $nameservers[1],
+            'ns3' => $nameservers[2],
+            'ns4' => $nameservers[3],
             'id' => $row['id'],
         ]);
     }

--- a/automation/src/Backend/LOOM.php
+++ b/automation/src/Backend/LOOM.php
@@ -758,34 +758,88 @@ final class LOOM extends AbstractDriver
         ]);
     }
 
-    public function getExpiredDomains(): array
+    public function getExpiredDomains(
+        int $limit = 500,
+        int $afterId = 0
+    ): array
     {
-        $stmt = $this->pdo->prepare("SELECT * FROM services WHERE type = 'domain' AND NOW() > expires_at");
+        $limit = max(1, min($limit, 1000));
+        $stmt = $this->pdo->prepare("
+            SELECT *
+            FROM services
+            WHERE type = 'domain'
+              AND status IN ('active', 'expired')
+              AND NOW() > expires_at
+              AND id > :after_id
+            ORDER BY id ASC
+            LIMIT :limit
+        ");
+        $stmt->bindValue(':after_id', max(0, $afterId), PDO::PARAM_INT);
+        $stmt->bindValue(':limit', $limit, PDO::PARAM_INT);
         $stmt->execute();
         $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
         foreach ($rows as &$row) {
             $row['domain_name'] = $row['service_name'];
+            $serviceConfig = json_decode((string)($row['config'] ?? ''), true);
+            $row['nameservers'] = is_array($serviceConfig['nameservers'] ?? null)
+                ? array_values($serviceConfig['nameservers'])
+                : [];
+            $row['errp_active'] = true;
         }
         unset($row);
 
         return $rows;
     }
 
-    public function updateExpiredDomainNameservers(array $row, string $ns1, string $ns2): void
+    public function getErrpDnsDomain(int $domainId): ?array
+    {
+        $stmt = $this->pdo->prepare("
+            SELECT *
+            FROM services
+            WHERE id = :id
+              AND type = 'domain'
+            LIMIT 1
+        ");
+        $stmt->execute(['id' => $domainId]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        if (!$row) {
+            return null;
+        }
+
+        $serviceConfig = json_decode((string)($row['config'] ?? ''), true);
+        $row['domain_name'] = $row['service_name'];
+        $row['nameservers'] = is_array($serviceConfig['nameservers'] ?? null)
+            ? array_values($serviceConfig['nameservers'])
+            : [];
+        $row['errp_active'] = in_array(
+            (string)$row['status'],
+            ['active', 'expired'],
+            true
+        );
+
+        return $row;
+    }
+
+    public function updateErrpDomainNameservers(
+        array $row,
+        array $nameservers
+    ): void
     {
         $stmt = $this->pdo->prepare("
             UPDATE services
             SET config = JSON_SET(
-                config,
-                '$.nameservers[0]', :ns1,
-                '$.nameservers[1]', :ns2
+                COALESCE(config, JSON_OBJECT()),
+                '$.nameservers', JSON_EXTRACT(:nameservers, '$')
             )
             WHERE id = :id AND type = 'domain'
         ");
         $stmt->execute([
-            'ns1' => $ns1,
-            'ns2' => $ns2,
+            'nameservers' => json_encode(
+                array_values($nameservers),
+                JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR
+            ),
             'id' => $row['id'],
         ]);
     }

--- a/automation/src/Backend/WHMCS.php
+++ b/automation/src/Backend/WHMCS.php
@@ -844,34 +844,113 @@ final class WHMCS extends AbstractDriver
         ]);
     }
 
-    public function getExpiredDomains(): array
+    public function getExpiredDomains(
+        int $limit = 500,
+        int $afterId = 0
+    ): array
     {
-        $stmt = $this->pdo->prepare("SELECT * FROM namingo_domain WHERE NOW() > exdate");
+        $limit = max(1, min($limit, 1000));
+        $stmt = $this->pdo->prepare("
+            SELECT nd.*
+            FROM namingo_domain nd
+            WHERE NOW() > nd.exdate
+              AND nd.id > :after_id
+              AND EXISTS (
+                    SELECT 1
+                    FROM tbldomains d
+                    WHERE LOWER(d.domain) = LOWER(nd.name)
+                      AND d.status IN ('Active', 'Expired', 'Grace')
+              )
+            ORDER BY nd.id ASC
+            LIMIT :limit
+        ");
+        $stmt->bindValue(':after_id', max(0, $afterId), PDO::PARAM_INT);
+        $stmt->bindValue(':limit', $limit, PDO::PARAM_INT);
         $stmt->execute();
         $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
         foreach ($rows as &$row) {
             $row['domain_name'] = $row['name'];
+            $row['expires_at'] = $row['exdate'];
+            $row['nameservers'] = array_values(array_filter([
+                $row['ns1'] ?? null,
+                $row['ns2'] ?? null,
+                $row['ns3'] ?? null,
+                $row['ns4'] ?? null,
+                $row['ns5'] ?? null,
+            ], static fn ($value): bool => trim((string)$value) !== ''));
+            $row['errp_active'] = true;
         }
         unset($row);
 
         return $rows;
     }
 
-    public function updateExpiredDomainNameservers(array $row, string $ns1, string $ns2): void
+    public function getErrpDnsDomain(int $domainId): ?array
     {
+        $stmt = $this->pdo->prepare("
+            SELECT nd.*,
+                   COALESCE((
+                       SELECT d.status
+                       FROM tbldomains d
+                       WHERE LOWER(d.domain) = LOWER(nd.name)
+                       ORDER BY d.id DESC
+                       LIMIT 1
+                   ), '') AS billing_status
+            FROM namingo_domain nd
+            WHERE nd.id = :id
+            LIMIT 1
+        ");
+        $stmt->execute(['id' => $domainId]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        if (!$row) {
+            return null;
+        }
+
+        $row['domain_name'] = $row['name'];
+        $row['expires_at'] = $row['exdate'];
+        $row['nameservers'] = array_values(array_filter([
+            $row['ns1'] ?? null,
+            $row['ns2'] ?? null,
+            $row['ns3'] ?? null,
+            $row['ns4'] ?? null,
+            $row['ns5'] ?? null,
+        ], static fn ($value): bool => trim((string)$value) !== ''));
+        $row['errp_active'] = in_array(
+            (string)$row['billing_status'],
+            ['Active', 'Expired', 'Grace'],
+            true
+        );
+
+        return $row;
+    }
+
+    public function updateErrpDomainNameservers(
+        array $row,
+        array $nameservers
+    ): void
+    {
+        $nameservers = array_pad(
+            array_slice(array_values($nameservers), 0, 5),
+            5,
+            null
+        );
         $stmt = $this->pdo->prepare("
             UPDATE namingo_domain
             SET ns1 = :ns1,
                 ns2 = :ns2,
-                ns3 = NULL,
-                ns4 = NULL,
-                ns5 = NULL
+                ns3 = :ns3,
+                ns4 = :ns4,
+                ns5 = :ns5
             WHERE id = :id
         ");
         $stmt->execute([
-            'ns1' => $ns1,
-            'ns2' => $ns2,
+            'ns1' => $nameservers[0],
+            'ns2' => $nameservers[1],
+            'ns3' => $nameservers[2],
+            'ns4' => $nameservers[3],
+            'ns5' => $nameservers[4],
             'id' => $row['id'],
         ]);
     }


### PR DESCRIPTION
## Summary

- persist one ERRP DNS lifecycle record per domain expiration in the existing registrar notification table; no schema migration or new table is required
- snapshot the live registry nameservers and the billing-system nameservers before any mutation
- update the registry first and update local nameservers only after EPP confirms success
- retry pending interruptions and restorations idempotently, without aborting the batch when one domain fails
- check renewals before new expirations and restore the RAE's saved DNS path on a five-minute schedule
- filter candidates by renewable billing/service status and ICANN gTLD scope, with an optional explicit TLD allowlist
- skip terminal registry states and paginate candidates/state rows so one bad or old row cannot starve the batch

## ICANN ERRP basis

This implements the DNS lifecycle required by [ICANN ERRP sections 2.2.2–2.2.6](https://www.icann.org/en/contracted-parties/consensus-policies/expired-registration-recovery-policy/expired-registration-recovery-policy-21-02-2024-en): interrupt the existing DNS path during the post-expiration period and restore the path set by the RAE immediately or as soon as commercially reasonable after renewal.

The configured interruption nameservers remain an operational prerequisite. If they direct HTTP traffic to a page while the name is renewable, that page must conspicuously state that the registration is expired and provide renewal instructions as required by section 2.2.4.

## Storage and compatibility

State is stored as JSON with notification type `errp_dns` in the tables already supplied by the integrations:

- WHMCS: `namingo_registrar_notifications`
- FOSSBilling/LOOM: `domain_registrar_notification`

Existing installations continue to use top-level `ns1`/`ns2` when `errp.nameservers` is absent. WHMCS uses its `gtld` setting and FOSSBilling uses `min_data_set` to infer policy scope. LOOM/custom deployments should set `errp.tlds` explicitly.

## Validation

- parsed all nine changed PHP files successfully with `php-parser`
- `git diff --check`
- verified the WHMCS and FOSSBilling notification/domain schemas
- verified the EPP client's `domainInfo()` and idempotent `domainUpdateNS()` response behavior
- verified the published branch is one commit ahead of `main` with the expected nine files

A live billing-database/EPP integration environment was not available, so no registry command was executed during validation.