### PR TITLE
Add Restored Names Accuracy hold enforcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Open source ICANN-accredited domain registrar management system.
 
 - **Contact Validation**: Performs ICANN-required and NIS2-compliant registrant contact validation and verification workflows.
 
+- **Restored Names Accuracy Policy**: Keeps qualifying names on registrar hold after RGP restoration until post-deletion contact accuracy is verified.
+
 - **Transfer Management (IRTP/ITRP)**: Handles inter-registrar domain transfers with secure authorization and policy-compliant workflows.
 
 - **ICANN Transfer Notification**: Sends the standardized losing-registrar transfer confirmation from registry EPP poll events, with durable audit evidence.

--- a/automation/config.php.dist
+++ b/automation/config.php.dist
@@ -85,6 +85,13 @@ $config = array(
     'registration_data_update_url' => 'https://example.com/account/domains',
     'registration_agreement_url' => 'https://example.com/legal/domain-registration-agreement',
 
+    // Restored Names Accuracy Policy. WHMCS/FOSSBilling normally infer gTLD
+    // applicability from their registrar configuration. Set an explicit list
+    // for LOOM/custom backends or to restrict enforcement further.
+    'restored_names_accuracy' => [
+        'tlds' => [], // e.g. ['com', 'net', 'org']
+    ],
+
     // URS Configuration
     'urs_imap_host' => '{your_imap_server:993/imap/ssl}INBOX',
     'urs_imap_username' => 'your_username',

--- a/automation/cron.php
+++ b/automation/cron.php
@@ -51,6 +51,11 @@ $php = escapeshellarg(PHP_BINARY);
 $addJob('escrow', $php . ' /opt/registrar/automation/escrow.php', '0 17 * * 5');
 $addJob('epp-poll', $php . ' /opt/registrar/automation/epp_poll.php', '*/5 * * * *');
 $addJob('transfer-notify', $php . ' /opt/registrar/automation/transfer_notify.php', '*/5 * * * *');
+$addJob(
+    'restored-names-accuracy',
+    $php . ' /opt/registrar/automation/restored_names_accuracy.php',
+    '*/5 * * * *'
+);
 
 if ($cronJobConfig['tools']) {
     $addJob('wdrp', $php . ' /opt/registrar/automation/wdrp.php', '0 0 * * *');

--- a/automation/restored_names_accuracy.php
+++ b/automation/restored_names_accuracy.php
@@ -1,0 +1,622 @@
+<?php
+/**
+ * ICANN Restored Names Accuracy Policy enforcement.
+ *
+ * Qualifying deletion hook (call only after a successful registry deletion):
+ * php restored_names_accuracy.php --deleted --domain=example.test \
+ *     --reason=false_contact_data --note="case/reference"
+ *
+ * RGP restoration hook (call after every successful restoration):
+ * php restored_names_accuracy.php --restored --domain=example.test
+ *
+ * External accuracy-verification hook:
+ * php restored_names_accuracy.php --verified --domain=example.test \
+ *     --note="ticket/reference"
+ *
+ * With no action option, the script retries and confirms every required hold.
+ * Policy: https://www.icann.org/en/contracted-parties/consensus-policies/
+ * restored-names-accuracy-policy/restored-names-accuracy-policy-01-01-2020-en
+ *
+ * @license MIT
+ */
+
+declare(strict_types=1);
+
+use Registrar\Backend\DriverFactory;
+
+date_default_timezone_set('UTC');
+
+require_once __DIR__ . '/config.php';
+require_once __DIR__ . '/helpers.php';
+require_once __DIR__ . '/vendor/autoload.php';
+
+const RESTORED_ACCURACY_BATCH_SIZE = 500;
+
+function restoredAccuracyNow(): DateTimeImmutable
+{
+    return new DateTimeImmutable('now', new DateTimeZone('UTC'));
+}
+
+function restoredAccuracyJsonTime(DateTimeImmutable $date): string
+{
+    return $date->setTimezone(new DateTimeZone('UTC'))->format('Y-m-d\TH:i:s.v\Z');
+}
+
+function restoredAccuracyDatabaseTime(DateTimeImmutable $date): string
+{
+    return $date->setTimezone(new DateTimeZone('UTC'))->format('Y-m-d H:i:s.v');
+}
+
+function restoredAccuracyDomain(string $domain): string
+{
+    $domain = strtolower(rtrim(trim($domain), '.'));
+    if (function_exists('idn_to_ascii')) {
+        $domain = strtolower((string)(
+            idn_to_ascii($domain, IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46) ?: $domain
+        ));
+    }
+
+    if (strlen($domain) > 253
+        || !str_contains($domain, '.')
+        || !preg_match(
+            '/^(?=.{1,253}$)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+'
+            . '[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/',
+            $domain
+        )) {
+        throw new InvalidArgumentException("Invalid domain name: {$domain}");
+    }
+
+    return $domain;
+}
+
+function restoredAccuracyMetadata(array $row): array
+{
+    $metadata = json_decode((string)($row['metadata'] ?? ''), true);
+    if (!is_array($metadata)) {
+        throw new RuntimeException(
+            'Invalid Restored Names Accuracy metadata for notification '
+            . (int)($row['id'] ?? 0)
+        );
+    }
+
+    return $metadata;
+}
+
+function restoredAccuracyCanonicalize(mixed $value): mixed
+{
+    if (!is_array($value)) {
+        return is_scalar($value) || $value === null ? $value : (string)$value;
+    }
+    if (!array_is_list($value)) {
+        ksort($value, SORT_STRING);
+    }
+    foreach ($value as $key => $item) {
+        $value[$key] = restoredAccuracyCanonicalize($item);
+    }
+
+    return $value;
+}
+
+function restoredAccuracyHash(mixed $value): string
+{
+    return hash('sha256', json_encode(
+        restoredAccuracyCanonicalize($value),
+        JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
+    ));
+}
+
+function restoredAccuracyContactData(array $row): array
+{
+    if (is_array($row['contact_data'] ?? null)) {
+        return $row['contact_data'];
+    }
+    if (is_array($row['registrant_data'] ?? null)) {
+        return ['registrant' => $row['registrant_data']];
+    }
+
+    return ['registrant' => [
+        'name' => $row['registrant_name'] ?? '',
+        'organization' => $row['registrant_organization'] ?? '',
+        'street' => $row['registrant_street'] ?? '',
+        'city' => $row['registrant_city'] ?? '',
+        'state' => $row['registrant_state'] ?? '',
+        'postal_code' => $row['registrant_postal_code'] ?? '',
+        'country' => $row['registrant_country'] ?? '',
+        'phone' => $row['registrant_phone'] ?? '',
+        'email' => $row['registrant_email'] ?? '',
+    ]];
+}
+
+function restoredAccuracyDomainSnapshot(
+    object $driver,
+    string $domain,
+    DateTimeImmutable $now,
+    object $log
+): array {
+    try {
+        foreach ($driver->getValidationRows(restoredAccuracyDatabaseTime($now)) as $row) {
+            $candidate = (string)($row['domain_name'] ?? $row['name'] ?? '');
+            if ($candidate === '') {
+                continue;
+            }
+            try {
+                $candidate = restoredAccuracyDomain($candidate);
+            } catch (Throwable) {
+                continue;
+            }
+            if ($candidate !== $domain) {
+                continue;
+            }
+
+            $rawId = $row['domain_id'] ?? $row['id'] ?? null;
+            return [
+                'domain_id' => is_numeric($rawId) ? (int)$rawId : null,
+                'contact_hash' => restoredAccuracyHash(restoredAccuracyContactData($row)),
+            ];
+        }
+    } catch (Throwable $e) {
+        $log->warning(
+            "Could not capture current contact hash for {$domain}: {$e->getMessage()}"
+        );
+    }
+
+    return ['domain_id' => null, 'contact_hash' => ''];
+}
+
+function restoredAccuracyBoolean(mixed $value): bool
+{
+    if (is_bool($value)) {
+        return $value;
+    }
+
+    return in_array(strtolower(trim((string)$value)), ['1', 'true', 'yes', 'on'], true);
+}
+
+function restoredAccuracyConfiguredTlds(array $config): array
+{
+    $value = $config['restored_names_accuracy']['tlds'] ?? [];
+    if (is_string($value)) {
+        $value = preg_split('/[\s,]+/', $value) ?: [];
+    }
+    if (!is_array($value)) {
+        throw new InvalidArgumentException('restored_names_accuracy.tlds must be an array or string.');
+    }
+
+    return array_values(array_unique(array_filter(array_map(
+        static fn (mixed $tld): string => strtolower(ltrim(trim((string)$tld), '.')),
+        $value
+    ))));
+}
+
+function restoredAccuracyApplies(string $domain, array $eppConfiguration, array $config): bool
+{
+    $configuredTlds = restoredAccuracyConfiguredTlds($config);
+    $tld = (string)substr(strrchr($domain, '.'), 1);
+    if ($configuredTlds !== []) {
+        return in_array($tld, $configuredTlds, true);
+    }
+
+    $settings = is_array($eppConfiguration['config'] ?? null)
+        ? $eppConfiguration['config']
+        : [];
+    if (array_key_exists('gtld', $settings)) {
+        return restoredAccuracyBoolean($settings['gtld']);
+    }
+    if (array_key_exists('min_data_set', $settings)) {
+        return restoredAccuracyBoolean($settings['min_data_set']);
+    }
+
+    throw new RuntimeException(
+        'Cannot determine whether ' . $domain . ' is subject to ICANN policy. '
+        . 'Configure restored_names_accuracy.tlds.'
+    );
+}
+
+function restoredAccuracyEppSucceeded(mixed $result): bool
+{
+    if (!is_array($result) || isset($result['error'])) {
+        return false;
+    }
+    $code = (int)($result['code'] ?? 0);
+
+    return $code >= 1000 && $code < 2000;
+}
+
+function restoredAccuracyRegistryStatuses(object $epp, string $domain): array
+{
+    $result = $epp->domainInfo(['domainname' => $domain]);
+    if (!restoredAccuracyEppSucceeded($result)) {
+        $reason = is_array($result)
+            ? ($result['error'] ?? $result['msg'] ?? 'unknown response')
+            : 'invalid response';
+        throw new RuntimeException("EPP domain info failed for {$domain}: {$reason}");
+    }
+
+    return array_values(array_map('strval', (array)($result['status'] ?? [])));
+}
+
+function restoredAccuracyChangeStatus(
+    object $epp,
+    string $domain,
+    string $command
+): void {
+    $result = $epp->domainUpdateStatus([
+        'domainname' => $domain,
+        'command' => $command,
+        'status' => 'clientHold',
+    ]);
+    if (!restoredAccuracyEppSucceeded($result)) {
+        $reason = is_array($result)
+            ? ($result['error'] ?? $result['msg'] ?? 'unknown response')
+            : 'invalid response';
+        throw new RuntimeException(
+            "EPP {$command} clientHold failed for {$domain}: {$reason}"
+        );
+    }
+}
+
+function restoredAccuracyVerificationIsFresh(array $metadata): bool
+{
+    $verifiedAt = (string)($metadata['verification']['verified_at'] ?? '');
+    $deletedAt = (string)($metadata['deleted_at'] ?? '');
+    if ($verifiedAt === '' || $deletedAt === '') {
+        return false;
+    }
+
+    try {
+        return new DateTimeImmutable($verifiedAt) > new DateTimeImmutable($deletedAt);
+    } catch (Throwable) {
+        return false;
+    }
+}
+
+function restoredAccuracyProcessRecord(
+    object $driver,
+    array $row,
+    object $log
+): bool {
+    $id = (int)$row['id'];
+    $domain = trim((string)($row['domain'] ?? ''));
+    $metadata = [];
+    $now = restoredAccuracyNow();
+    $epp = null;
+
+    try {
+        $domain = restoredAccuracyDomain($domain);
+        $metadata = restoredAccuracyMetadata($row);
+        $metadata['attempts'] = (int)($metadata['attempts'] ?? 0) + 1;
+        $metadata['last_checked_at'] = restoredAccuracyJsonTime($now);
+
+        $epp = epp_client($driver->getEppConfiguration($domain));
+        $statuses = restoredAccuracyRegistryStatuses($epp, $domain);
+        $hold = is_array($metadata['hold'] ?? null) ? $metadata['hold'] : [];
+        $owned = (bool)($hold['currently_owned'] ?? false);
+
+        if (!in_array('clientHold', $statuses, true)) {
+            restoredAccuracyChangeStatus($epp, $domain, 'add');
+            $statuses = restoredAccuracyRegistryStatuses($epp, $domain);
+            if (!in_array('clientHold', $statuses, true)) {
+                throw new RuntimeException(
+                    "Registry did not confirm clientHold for {$domain}"
+                );
+            }
+            $owned = true;
+            $hold['added_by_process'] = true;
+            $log->info("Restored Names Accuracy added clientHold to {$domain}.");
+        }
+
+        $hold['currently_owned'] = $owned;
+        $hold['effective_at'] = $hold['effective_at'] ?? restoredAccuracyJsonTime($now);
+        $hold['last_confirmed_at'] = restoredAccuracyJsonTime($now);
+        $metadata['hold'] = $hold;
+        $metadata['state'] = 'on_hold';
+        $metadata['last_error'] = null;
+        $driver->updateRestoredAccuracyNotificationMetadata($id, $metadata);
+
+        if (!restoredAccuracyVerificationIsFresh($metadata)) {
+            return true;
+        }
+
+        if ($owned) {
+            restoredAccuracyChangeStatus($epp, $domain, 'rem');
+            $statuses = restoredAccuracyRegistryStatuses($epp, $domain);
+            if (in_array('clientHold', $statuses, true)) {
+                throw new RuntimeException(
+                    "Registry did not confirm clientHold removal for {$domain}"
+                );
+            }
+            $metadata['hold']['currently_owned'] = false;
+            $metadata['hold']['removed_at'] = restoredAccuracyJsonTime($now);
+            $log->info("Restored Names Accuracy removed its clientHold from {$domain}.");
+        }
+
+        $metadata['state'] = 'released';
+        $metadata['released_at'] = restoredAccuracyJsonTime($now);
+        $metadata['last_error'] = null;
+        $driver->updateRestoredAccuracyNotificationMetadata($id, $metadata);
+
+        return true;
+    } catch (Throwable $e) {
+        if ($metadata !== []) {
+            $metadata['last_error'] = $e->getMessage();
+            try {
+                $driver->updateRestoredAccuracyNotificationMetadata($id, $metadata);
+            } catch (Throwable $storageError) {
+                $log->error(
+                    "Could not persist Restored Names Accuracy error for {$domain}: "
+                    . $storageError->getMessage()
+                );
+            }
+        }
+        $log->error("Restored Names Accuracy failed for {$domain}: {$e->getMessage()}");
+
+        return false;
+    } finally {
+        if ($epp !== null) {
+            epp_client_logout($epp);
+        }
+    }
+}
+
+function restoredAccuracyReason(string $reason): string
+{
+    $reason = strtolower(trim($reason));
+    return match ($reason) {
+        'false_contact_data', 'false-contact-data', 'inaccuracy', 'inaccurate_data'
+            => 'false_contact_data',
+        'non_response', 'non-response', 'no_response' => 'non_response',
+        default => throw new InvalidArgumentException(
+            'Reason must be false_contact_data or non_response.'
+        ),
+    };
+}
+
+function restoredAccuracyRecordDeletion(
+    object $driver,
+    string $domain,
+    string $reason,
+    ?string $note,
+    array $config,
+    object $log
+): bool {
+    $eppConfiguration = $driver->getEppConfiguration($domain);
+    if (!restoredAccuracyApplies($domain, $eppConfiguration, $config)) {
+        $log->info("Restored Names Accuracy does not apply to {$domain}; no state recorded.");
+        return true;
+    }
+
+    $existing = $driver->findRestoredAccuracyNotification($domain);
+    if ($existing !== null) {
+        $metadata = restoredAccuracyMetadata($existing);
+        if (($metadata['state'] ?? null) === 'deleted') {
+            $log->info("Qualifying deletion for {$domain} is already recorded.");
+            return true;
+        }
+        throw new RuntimeException(
+            "An unfinished Restored Names Accuracy lifecycle already exists for {$domain}."
+        );
+    }
+
+    $now = restoredAccuracyNow();
+    $snapshot = restoredAccuracyDomainSnapshot($driver, $domain, $now, $log);
+    $driver->storeRestoredAccuracyNotification([
+        'domain_id' => $snapshot['domain_id'],
+        'domain' => $domain,
+        'subject' => 'Restored Names Accuracy policy state for ' . $domain,
+        'body' => 'Qualifying deletion and restoration hold audit state.',
+        'metadata' => [
+            'policy' => 'restored_names_accuracy',
+            'version' => 1,
+            'state' => 'deleted',
+            'deletion_reason' => $reason,
+            'deleted_at' => restoredAccuracyJsonTime($now),
+            'deletion_contact_hash' => $snapshot['contact_hash'],
+            'deletion_note' => $note,
+            'restored_at' => null,
+            'hold' => [
+                'added_by_process' => false,
+                'currently_owned' => false,
+                'effective_at' => null,
+            ],
+            'verification' => null,
+            'released_at' => null,
+            'attempts' => 0,
+            'last_checked_at' => null,
+            'last_error' => null,
+        ],
+        'sent_at' => restoredAccuracyDatabaseTime($now),
+    ]);
+    $log->info("Recorded qualifying deletion for {$domain} ({$reason}).");
+
+    return true;
+}
+
+function restoredAccuracyRecordRestoration(
+    object $driver,
+    string $domain,
+    object $log
+): bool {
+    $row = $driver->findRestoredAccuracyNotification($domain);
+    if ($row === null) {
+        $log->info("No qualifying deletion is recorded for restored domain {$domain}.");
+        return true;
+    }
+
+    $metadata = restoredAccuracyMetadata($row);
+    if (($metadata['state'] ?? null) === 'deleted') {
+        $metadata['state'] = 'hold_pending';
+        $metadata['restored_at'] = restoredAccuracyJsonTime(restoredAccuracyNow());
+        $metadata['last_error'] = null;
+        $driver->updateRestoredAccuracyNotificationMetadata((int)$row['id'], $metadata);
+        $row['metadata'] = json_encode(
+            $metadata,
+            JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
+        );
+    }
+
+    return restoredAccuracyProcessRecord($driver, $row, $log);
+}
+
+function restoredAccuracyRecordVerification(
+    object $driver,
+    string $domain,
+    string $note,
+    object $log
+): bool {
+    $row = $driver->findRestoredAccuracyNotification($domain);
+    if ($row === null) {
+        $log->info("No active Restored Names Accuracy state exists for {$domain}.");
+        return true;
+    }
+
+    $now = restoredAccuracyNow();
+    $snapshot = restoredAccuracyDomainSnapshot($driver, $domain, $now, $log);
+    $driver->markRestoredAccuracyVerified(
+        $domain,
+        $snapshot['domain_id'],
+        $snapshot['contact_hash'],
+        restoredAccuracyJsonTime($now),
+        'external_hook',
+        $note
+    );
+    $log->info("Recorded post-deletion contact accuracy verification for {$domain}.");
+
+    $row = $driver->findRestoredAccuracyNotification($domain);
+    if ($row !== null
+        && in_array(
+            restoredAccuracyMetadata($row)['state'] ?? null,
+            ['hold_pending', 'on_hold'],
+            true
+        )) {
+        return restoredAccuracyProcessRecord($driver, $row, $log);
+    }
+
+    return true;
+}
+
+function restoredAccuracyRunCron(object $driver, object $log): bool
+{
+    $afterId = 0;
+    $hadErrors = false;
+
+    do {
+        $rows = $driver->getPendingRestoredAccuracyNotifications(
+            $afterId,
+            RESTORED_ACCURACY_BATCH_SIZE
+        );
+        foreach ($rows as $row) {
+            $afterId = max($afterId, (int)$row['id']);
+            if (!restoredAccuracyProcessRecord($driver, $row, $log)) {
+                $hadErrors = true;
+            }
+        }
+    } while (count($rows) === RESTORED_ACCURACY_BATCH_SIZE);
+
+    return !$hadErrors;
+}
+
+function runRestoredNamesAccuracy(): int
+{
+    global $config;
+
+    $log = setupLogger(
+        '/var/log/namingo/restored_names_accuracy.log',
+        'RESTORED_NAMES_ACCURACY'
+    );
+    $options = getopt('', [
+        'deleted', 'restored', 'verified', 'domain:', 'reason:', 'note:', 'help',
+    ]) ?: [];
+
+    if (array_key_exists('help', $options)) {
+        fwrite(STDOUT, "Usage:\n"
+            . "  php restored_names_accuracy.php --deleted --domain=NAME "
+            . "--reason=false_contact_data|non_response [--note=REFERENCE]\n"
+            . "  php restored_names_accuracy.php --restored --domain=NAME\n"
+            . "  php restored_names_accuracy.php --verified --domain=NAME --note=REFERENCE\n"
+            . "  php restored_names_accuracy.php\n");
+        return 0;
+    }
+
+    $actions = array_filter(
+        ['deleted', 'restored', 'verified'],
+        static fn (string $action): bool => array_key_exists($action, $options)
+    );
+    if (count($actions) > 1) {
+        fwrite(STDERR, "Choose only one of --deleted, --restored, or --verified.\n");
+        return 1;
+    }
+
+    $domain = '';
+    if ($actions !== []) {
+        try {
+            $domain = restoredAccuracyDomain((string)($options['domain'] ?? ''));
+        } catch (Throwable $e) {
+            fwrite(STDERR, $e->getMessage() . PHP_EOL);
+            return 1;
+        }
+    }
+
+    $pdo = null;
+    $locked = false;
+    $lockName = 'namingo-restored-names-accuracy';
+    $log->info('job started.');
+
+    try {
+        $pdo = new PDO(
+            "mysql:host={$config['db']['host']};dbname={$config['db']['dbname']}",
+            $config['db']['username'],
+            $config['db']['password'],
+            [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]
+        );
+        $driver = DriverFactory::create($pdo, $config, $log);
+
+        $lock = $pdo->prepare('SELECT GET_LOCK(:name, 30)');
+        $lock->execute(['name' => $lockName]);
+        $locked = (int)$lock->fetchColumn() === 1;
+        if (!$locked) {
+            throw new RuntimeException('Another Restored Names Accuracy job is running.');
+        }
+
+        $action = $actions === [] ? null : (string)reset($actions);
+        $ok = match ($action) {
+            'deleted' => restoredAccuracyRecordDeletion(
+                $driver,
+                $domain,
+                restoredAccuracyReason((string)($options['reason'] ?? '')),
+                isset($options['note']) ? trim((string)$options['note']) : null,
+                $config,
+                $log
+            ),
+            'restored' => restoredAccuracyRecordRestoration($driver, $domain, $log),
+            'verified' => restoredAccuracyRecordVerification(
+                $driver,
+                $domain,
+                trim((string)($options['note'] ?? '')) !== ''
+                    ? trim((string)$options['note'])
+                    : throw new InvalidArgumentException('--note is required with --verified.'),
+                $log
+            ),
+            default => restoredAccuracyRunCron($driver, $log),
+        };
+
+        $log->info($ok ? 'job completed.' : 'job completed with errors.');
+        return $ok ? 0 : 1;
+    } catch (Throwable $e) {
+        $log->error('Restored Names Accuracy job failed: ' . $e->getMessage());
+        fwrite(STDERR, $e->getMessage() . PHP_EOL);
+        return 1;
+    } finally {
+        if ($locked && $pdo instanceof PDO) {
+            try {
+                $unlock = $pdo->prepare('SELECT RELEASE_LOCK(:name)');
+                $unlock->execute(['name' => $lockName]);
+            } catch (Throwable $e) {
+                $log->error('Restored Names Accuracy lock release failed: ' . $e->getMessage());
+            }
+        }
+    }
+}
+
+if (!defined('NAMINGO_RESTORED_ACCURACY_NO_AUTORUN')) {
+    exit(runRestoredNamesAccuracy());
+}

--- a/automation/src/Backend/AbstractDriver.php
+++ b/automation/src/Backend/AbstractDriver.php
@@ -6,6 +6,8 @@ use PDO;
 
 abstract class AbstractDriver implements DriverInterface
 {
+    private const RESTORED_ACCURACY_TYPE = 'restored_accuracy';
+
     public function __construct(
         protected PDO $pdo,
         protected array $config,
@@ -18,6 +20,226 @@ abstract class AbstractDriver implements DriverInterface
         throw new \RuntimeException(
             static::class . ' does not implement EPP account enumeration.'
         );
+    }
+
+    public function findRestoredAccuracyNotification(string $domain): ?array
+    {
+        $table = $this->notificationTable();
+        $stmt = $this->pdo->prepare("
+            SELECT id, domain_id, domain, metadata, sent_at
+            FROM {$table}
+            WHERE type = '" . self::RESTORED_ACCURACY_TYPE . "'
+              AND LOWER(domain) = LOWER(:domain)
+              AND JSON_UNQUOTE(JSON_EXTRACT(metadata, '$.state'))
+                    IN ('deleted', 'hold_pending', 'on_hold')
+            ORDER BY id DESC
+            LIMIT 1
+        ");
+        $stmt->execute(['domain' => $domain]);
+
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        return $row ?: null;
+    }
+
+    public function storeRestoredAccuracyNotification(array $data): int
+    {
+        $table = $this->notificationTable();
+        $stmt = $this->pdo->prepare("
+            INSERT INTO {$table} (
+                domain_id,
+                domain,
+                type,
+                recipient,
+                subject,
+                body,
+                metadata,
+                sent_at
+            ) VALUES (
+                :domain_id,
+                :domain,
+                '" . self::RESTORED_ACCURACY_TYPE . "',
+                '',
+                :subject,
+                :body,
+                :metadata,
+                :sent_at
+            )
+        ");
+        $stmt->execute([
+            'domain_id' => $data['domain_id'] ?? null,
+            'domain' => (string)$data['domain'],
+            'subject' => (string)($data['subject'] ?? 'Restored Names Accuracy state'),
+            'body' => (string)($data['body'] ?? 'Restored Names Accuracy lifecycle state.'),
+            'metadata' => $this->encodeNotificationMetadata($data['metadata'] ?? []),
+            'sent_at' => (string)$data['sent_at'],
+        ]);
+
+        return (int)$this->pdo->lastInsertId();
+    }
+
+    public function updateRestoredAccuracyNotificationMetadata(
+        int $id,
+        array $metadata
+    ): void {
+        $table = $this->notificationTable();
+        $stmt = $this->pdo->prepare("
+            UPDATE {$table}
+            SET metadata = :metadata
+            WHERE id = :id
+              AND type = '" . self::RESTORED_ACCURACY_TYPE . "'
+        ");
+        $stmt->execute([
+            'metadata' => $this->encodeNotificationMetadata($metadata),
+            'id' => $id,
+        ]);
+
+        if ($stmt->rowCount() === 0) {
+            $check = $this->pdo->prepare("
+                SELECT 1
+                FROM {$table}
+                WHERE id = :id
+                  AND type = '" . self::RESTORED_ACCURACY_TYPE . "'
+            ");
+            $check->execute(['id' => $id]);
+            if (!$check->fetchColumn()) {
+                throw new \RuntimeException(
+                    "Restored Names Accuracy notification not found: {$id}"
+                );
+            }
+        }
+    }
+
+    public function getPendingRestoredAccuracyNotifications(
+        int $afterId = 0,
+        int $limit = 500
+    ): array {
+        $table = $this->notificationTable();
+        $limit = max(1, min($limit, 1000));
+        $stmt = $this->pdo->prepare("
+            SELECT id, domain_id, domain, metadata, sent_at
+            FROM {$table}
+            WHERE type = '" . self::RESTORED_ACCURACY_TYPE . "'
+              AND id > :after_id
+              AND JSON_UNQUOTE(JSON_EXTRACT(metadata, '$.state'))
+                    IN ('hold_pending', 'on_hold')
+            ORDER BY id ASC
+            LIMIT :limit
+        ");
+        $stmt->bindValue(':after_id', max(0, $afterId), PDO::PARAM_INT);
+        $stmt->bindValue(':limit', $limit, PDO::PARAM_INT);
+        $stmt->execute();
+
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    public function getActiveRestoredAccuracyDomains(): array
+    {
+        $table = $this->notificationTable();
+        $stmt = $this->pdo->query("
+            SELECT DISTINCT LOWER(domain)
+            FROM {$table}
+            WHERE type = '" . self::RESTORED_ACCURACY_TYPE . "'
+              AND JSON_UNQUOTE(JSON_EXTRACT(metadata, '$.state'))
+                    IN ('deleted', 'hold_pending', 'on_hold')
+        ");
+
+        return array_values(array_filter(array_map(
+            'strval',
+            $stmt->fetchAll(PDO::FETCH_COLUMN)
+        )));
+    }
+
+    public function markRestoredAccuracyVerified(
+        string $domain,
+        ?int $domainId,
+        string $contactHash,
+        string $verifiedAt,
+        string $method,
+        ?string $note = null
+    ): bool {
+        $row = $this->findRestoredAccuracyNotification($domain);
+        if ($row === null) {
+            return false;
+        }
+
+        $metadata = json_decode((string)($row['metadata'] ?? ''), true);
+        if (!is_array($metadata)) {
+            throw new \RuntimeException(
+                'Invalid Restored Names Accuracy metadata for ' . $domain
+            );
+        }
+
+        $deletedAtValue = (string)($metadata['deleted_at'] ?? '');
+        if ($deletedAtValue === '' || $verifiedAt === '') {
+            throw new \RuntimeException(
+                'Missing Restored Names Accuracy timestamp for ' . $domain
+            );
+        }
+
+        try {
+            $deletedAt = new \DateTimeImmutable($deletedAtValue);
+            $verified = new \DateTimeImmutable($verifiedAt);
+        } catch (\Throwable $e) {
+            throw new \RuntimeException(
+                'Invalid Restored Names Accuracy verification timestamp for ' . $domain,
+                0,
+                $e
+            );
+        }
+
+        if ($verified <= $deletedAt) {
+            return false;
+        }
+
+        $deletedHash = (string)($metadata['deletion_contact_hash'] ?? '');
+        $confirmedMethods = ['email', 'manual', 'external_hook'];
+        $freshConfirmation = in_array($method, $confirmedMethods, true);
+        $contactChanged = $deletedHash !== ''
+            && $contactHash !== ''
+            && !hash_equals($deletedHash, $contactHash);
+
+        if (!$freshConfirmation && !$contactChanged) {
+            return false;
+        }
+
+        $existing = is_array($metadata['verification'] ?? null)
+            ? $metadata['verification']
+            : [];
+        if (($existing['verified_at'] ?? null) === $verifiedAt
+            && ($existing['contact_hash'] ?? null) === $contactHash
+            && ($existing['method'] ?? null) === $method
+            && ($existing['note'] ?? null) === $note) {
+            return false;
+        }
+
+        $table = $this->notificationTable();
+        $stmt = $this->pdo->prepare("
+            UPDATE {$table}
+            SET domain_id = COALESCE(domain_id, :domain_id),
+                metadata = JSON_SET(
+                    COALESCE(metadata, JSON_OBJECT()),
+                    '$.verification', JSON_OBJECT(
+                        'contact_hash', :contact_hash,
+                        'method', :method,
+                        'verified_at', :verified_at,
+                        'note', :note
+                    )
+                )
+            WHERE id = :id
+              AND type = '" . self::RESTORED_ACCURACY_TYPE . "'
+              AND JSON_UNQUOTE(JSON_EXTRACT(metadata, '$.state'))
+                    IN ('deleted', 'hold_pending', 'on_hold')
+        ");
+        $stmt->bindValue(':domain_id', $domainId, $domainId === null ? PDO::PARAM_NULL : PDO::PARAM_INT);
+        $stmt->bindValue(':contact_hash', $contactHash);
+        $stmt->bindValue(':method', $method);
+        $stmt->bindValue(':verified_at', $verifiedAt);
+        $stmt->bindValue(':note', $note, $note === null ? PDO::PARAM_NULL : PDO::PARAM_STR);
+        $stmt->bindValue(':id', (int)$row['id'], PDO::PARAM_INT);
+        $stmt->execute();
+
+        return $stmt->rowCount() > 0;
     }
 
     public function findEppPollNotification(
@@ -275,5 +497,15 @@ abstract class AbstractDriver implements DriverInterface
     protected function notificationTable(): string
     {
         return 'registrar_notifications';
+    }
+
+    private function encodeNotificationMetadata(array $metadata): string
+    {
+        return json_encode(
+            $metadata,
+            JSON_UNESCAPED_SLASHES
+            | JSON_UNESCAPED_UNICODE
+            | JSON_THROW_ON_ERROR
+        );
     }
 }

--- a/automation/src/Backend/DriverInterface.php
+++ b/automation/src/Backend/DriverInterface.php
@@ -28,6 +28,31 @@ interface DriverInterface
 
     public function getEppConfiguration(string $domain): array;
 
+    public function findRestoredAccuracyNotification(string $domain): ?array;
+
+    public function storeRestoredAccuracyNotification(array $data): int;
+
+    public function updateRestoredAccuracyNotificationMetadata(
+        int $id,
+        array $metadata
+    ): void;
+
+    public function getPendingRestoredAccuracyNotifications(
+        int $afterId = 0,
+        int $limit = 500
+    ): array;
+
+    public function getActiveRestoredAccuracyDomains(): array;
+
+    public function markRestoredAccuracyVerified(
+        string $domain,
+        ?int $domainId,
+        string $contactHash,
+        string $verifiedAt,
+        string $method,
+        ?string $note = null
+    ): bool;
+
     public function findEppPollNotification(
         string $recipient,
         string $accountKey,

--- a/automation/validation.php
+++ b/automation/validation.php
@@ -215,6 +215,49 @@ function validationClose(PDO $pdo, int $id, DateTimeImmutable $now): void
     ]);
 }
 
+function validationPublishRestoredAccuracy(
+    object $driver,
+    array $row,
+    array $state,
+    object $log,
+    bool &$hadErrors
+): void {
+    if (($state['status'] ?? null) !== 'verified' || empty($state['verified_at'])) {
+        return;
+    }
+
+    try {
+        $domain = strtolower(rtrim(
+            validationDomainAscii((string)$row['domain_name']),
+            '.'
+        ));
+        $domainId = is_numeric($row['domain_id'] ?? null)
+            ? (int)$row['domain_id']
+            : null;
+        if ($driver->markRestoredAccuracyVerified(
+            $domain,
+            $domainId,
+            (string)$state['contact_data_hash'],
+            (string)$state['verified_at'],
+            (string)($state['verification_method'] ?? ''),
+            isset($state['verification_note'])
+                ? (string)$state['verification_note']
+                : null
+        )) {
+            $log->info(
+                "Published post-deletion contact verification for restored domain {$domain}."
+            );
+        }
+    } catch (Throwable $e) {
+        validationError(
+            $log,
+            'Restored Names Accuracy verification publish failed for '
+                . (string)$row['domain_name'] . ': ' . $e->getMessage(),
+            $hadErrors
+        );
+    }
+}
+
 function validationContactData(array $row): array
 {
     if (is_array($row['contact_data'] ?? null)) {
@@ -791,6 +834,32 @@ function runValidation(): int
                 && ((int)$state['client_hold_added'] === 1
                     || (int)$state['client_transfer_prohibited_added'] === 1)) {
                 validationRestore($pdo, $driver, $domains[$domainId], $state, $log, $hadErrors, $now);
+            }
+        }
+
+        // Publish only exact, current validation states. The restored-name
+        // workflow additionally requires verification to post-date deletion.
+        $restoredAccuracyDomains = array_fill_keys(
+            $driver->getActiveRestoredAccuracyDomains(),
+            true
+        );
+        $states = validationCurrentStates($pdo, $backend);
+        foreach ($states as $domainId => $state) {
+            if (!isset($domains[$domainId]) || $state['status'] !== 'verified') {
+                continue;
+            }
+            $restoredDomain = strtolower(rtrim(
+                validationDomainAscii((string)$domains[$domainId]['domain_name']),
+                '.'
+            ));
+            if (isset($restoredAccuracyDomains[$restoredDomain])) {
+                validationPublishRestoredAccuracy(
+                    $driver,
+                    $domains[$domainId],
+                    $state,
+                    $log,
+                    $hadErrors
+                );
             }
         }
     } catch (Throwable $e) {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -553,3 +553,43 @@ URS notices and related files are archived under:
 ```
 
 unless `urs_archive_path` is changed in `config.php`.
+
+## 7. Restored Names Accuracy hooks
+
+The [ICANN Restored Names Accuracy Policy](https://www.icann.org/en/contracted-parties/consensus-policies/restored-names-accuracy-policy/restored-names-accuracy-policy-01-01-2020-en) applies when a name is deleted because of false contact data or non-response to registrar inquiries and is later restored from the Redemption Grace Period.
+
+After the registry accepts such a deletion, record its reason:
+
+```bash
+/usr/bin/php8.5 /opt/registrar/automation/restored_names_accuracy.php \
+  --deleted --domain=example.com --reason=false_contact_data \
+  --note="accuracy case/reference"
+```
+
+Use `--reason=non_response` for deletion following non-response. Do not emit this hook for other deletion reasons.
+
+The RGP restoration path must invoke the following hook immediately after every successful restoration:
+
+```bash
+/usr/bin/php8.5 /opt/registrar/automation/restored_names_accuracy.php \
+  --restored --domain=example.com
+```
+
+The hook returns a non-zero status unless registry `clientHold` can be confirmed. The mandatory five-minute cron retries every pending hold independently and never removes a pre-existing hold that this workflow did not add.
+
+The built-in validation job automatically publishes a release signal only for an exact verification completed after the qualifying deletion. An external contact-verification system can publish the same audited signal after the Registered Name Holder supplies updated and accurate data:
+
+```bash
+/usr/bin/php8.5 /opt/registrar/automation/restored_names_accuracy.php \
+  --verified --domain=example.com --note="ticket/verification reference"
+```
+
+The lifecycle is stored as notification type `restored_accuracy` in the existing backend table: `namingo_registrar_notifications` for WHMCS and `domain_registrar_notification` for FOSSBilling and LOOM. No database migration or additional table is required.
+
+WHMCS and FOSSBilling normally identify applicable gTLDs from their EPP registrar settings. LOOM and custom backends must configure the applicable TLDs explicitly:
+
+```php
+'restored_names_accuracy' => [
+    'tlds' => ['com', 'net', 'org'],
+],
+```


### PR DESCRIPTION
## Summary

Implements the [ICANN Restored Names Accuracy Policy](https://www.icann.org/en/contracted-parties/consensus-policies/restored-names-accuracy-policy/restored-names-accuracy-policy-01-01-2020-en) as a small stateful hook plus enforcement cron.

- records only qualifying deletions (`false_contact_data` or `non_response`)
- marks a successful RGP restoration `hold_pending` before attempting EPP
- adds and then re-confirms registry `clientHold` (Registrar Hold)
- retries every pending name independently every five minutes
- never removes a hold that this workflow did not add
- releases its own hold only after a qualifying contact verification completed after deletion
- consumes exact verification results from the existing validation workflow and also exposes an audited external `--verified` hook
- limits policy entry to configured/inferred gTLD scope
- stores the complete lifecycle as notification type `restored_accuracy`

No schema migration or new table is introduced. The generic notification-table override already maps storage to:

- WHMCS: `namingo_registrar_notifications`
- FOSSBilling/LOOM: `domain_registrar_notification`

## Required hook calls

After a registry-accepted deletion for one of the two policy reasons:

```bash
php automation/restored_names_accuracy.php --deleted \
  --domain=example.com --reason=false_contact_data \
  --note="accuracy case/reference"
```

Use `--reason=non_response` for non-response deletions.

Immediately after every successful RGP restoration:

```bash
php automation/restored_names_accuracy.php --restored --domain=example.com
```

An external accuracy process can attest updated and accurate data with:

```bash
php automation/restored_names_accuracy.php --verified \
  --domain=example.com --note="ticket/verification reference"
```

The restoration hook exits non-zero unless `clientHold` is confirmed. The scheduled job is a recovery/re-enforcement path, not a replacement for the synchronous restoration hook.

## Policy/safety details

- A deletion reason cannot be inferred reliably after the fact, so the qualifying deletion hook is deliberately explicit.
- State is persisted before the restoration EPP update, allowing cron recovery after interruption.
- EPP failures are isolated per name; one registry failure does not abort the remaining batch.
- Release requires a verification timestamp later than deletion. Same-data release requires fresh email/manual/external confirmation; an exact changed contact hash may reuse an already verified hash.
- Existing holds are preserved through explicit ownership metadata.
- WHMCS/FOSSBilling infer gTLD applicability from their registrar settings; LOOM/custom backends can use `restored_names_accuracy.tlds`.

## Verification

- rebased onto current `main` (including PR #40)
- changed PHP files parsed successfully with a PHP 8 parser
- `git diff --check` passes
- remote comparison: 1 commit ahead, 0 behind

A live registry EPP integration test was not possible in this workspace.