### PR TITLE
Add packaged ERRP DNS interruption service

### DIFF
--- a/dns/Caddyfile.example
+++ b/dns/Caddyfile.example
@@ -1,9 +1,9 @@
 # Add this site block to your existing /etc/caddy/Caddyfile.
-# Replace both example IPs with the addresses used by CoreDNS.
-# Binding to the interruption IPs prevents this catch-all site from
-# interfering with the registrar's normal Caddy virtual hosts.
+# Replace both example IPs with the dedicated interruption IP addresses.
+# The hostless http:// address accepts any expired domain Host header, while
+# bind confines the catch-all listener to the interruption addresses.
 
-http://203.0.113.10, http://203.0.113.11 {
+http:// {
     bind 203.0.113.10 203.0.113.11
 
     root * /var/www/namingo-expired
@@ -14,7 +14,7 @@ http://203.0.113.10, http://203.0.113.11 {
 
     header {
         Cache-Control "no-store, max-age=0"
-        Content-Security-Policy "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; base-uri 'none'; form-action 'self'; frame-ancestors 'none'"
+        Content-Security-Policy "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; base-uri 'none'; form-action 'none'; frame-ancestors 'none'"
         Permissions-Policy "camera=(), microphone=(), geolocation=()"
         Referrer-Policy "no-referrer"
         X-Content-Type-Options "nosniff"

--- a/dns/Caddyfile.example
+++ b/dns/Caddyfile.example
@@ -1,0 +1,23 @@
+# Add this site block to your existing /etc/caddy/Caddyfile.
+# Replace both example IPs with the addresses used by CoreDNS.
+# Binding to the interruption IPs prevents this catch-all site from
+# interfering with the registrar's normal Caddy virtual hosts.
+
+http://203.0.113.10, http://203.0.113.11 {
+    bind 203.0.113.10 203.0.113.11
+
+    root * /var/www/namingo-expired
+
+    # All paths show the same expiration page.
+    try_files {path} /index.html
+    file_server
+
+    header {
+        Cache-Control "no-store, max-age=0"
+        Content-Security-Policy "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; base-uri 'none'; form-action 'self'; frame-ancestors 'none'"
+        Permissions-Policy "camera=(), microphone=(), geolocation=()"
+        Referrer-Policy "no-referrer"
+        X-Content-Type-Options "nosniff"
+        X-Frame-Options "DENY"
+    }
+}

--- a/dns/Corefile.example
+++ b/dns/Corefile.example
@@ -1,0 +1,26 @@
+.:53 {
+    # Replace these with the two public IP addresses assigned to this host.
+    bind 203.0.113.10 203.0.113.11
+
+    # Every interrupted domain resolves to the web interruption service.
+    template IN A {
+        answer "{{ .Name }} 60 IN A 203.0.113.10"
+    }
+
+    # If the host has IPv6, add an AAAA template instead of returning NOERROR.
+    template IN AAAA {
+        rcode NOERROR
+    }
+
+    # Avoid directing mail to the interruption web host.
+    template IN MX {
+        answer "{{ .Name }} 60 IN MX 0 ."
+    }
+
+    # Return authoritative empty answers for record types not explicitly served.
+    template ANY ANY {
+        rcode NOERROR
+    }
+
+    errors
+}

--- a/dns/README.md
+++ b/dns/README.md
@@ -1,0 +1,162 @@
+# ERRP DNS interruption service
+
+This directory contains a minimal DNS and web setup for the DNS interruption performed by `automation/errp_dns.php` under the ICANN Expired Registration Recovery Policy (ERRP).
+
+The design is intentionally independent of WHMCS, FOSSBilling and LOOM. The registrar automation changes an expired domain's delegation to the configured interruption nameservers. CoreDNS then resolves requests for that domain to the interruption web IP, and Caddy serves a page that conspicuously identifies the expiration and tells the registrant how to renew.
+
+No database, API or domain synchronization is required on the DNS/web host.
+
+## Files
+
+- `Corefile.example` - catch-all authoritative CoreDNS configuration.
+- `Caddyfile.example` - block to add to an existing Caddyfile.
+- `index.html` - standalone expiration and renewal page.
+
+## Recommended layout
+
+A small deployment can use one host with two dedicated public IPv4 addresses:
+
+```text
+203.0.113.10  -> ns1.expired.registrar.example
+203.0.113.11  -> ns2.expired.registrar.example
+
+CoreDNS :53/udp + :53/tcp on both addresses
+Caddy   :80/tcp on both addresses
+```
+
+Two addresses on one host satisfy the practical two-nameserver configuration used by the registrar automation, but they are not high availability. Registrars that require infrastructure redundancy should place the nameservers on independent hosts/networks.
+
+The interruption addresses should be dedicated to this purpose. This makes the Caddy catch-all safe to add alongside the registrar's existing sites.
+
+## 1. Prepare the nameservers
+
+Choose two hostnames controlled by the registrar, for example:
+
+```text
+ns1.expired.registrar.example
+ns2.expired.registrar.example
+```
+
+Create A records for them pointing to the two public interruption IPs. If the nameserver hostnames are below a domain that requires registry glue, create the corresponding host/glue records with that registry as well.
+
+Allow inbound DNS on UDP and TCP port 53 and HTTP on TCP port 80.
+
+## 2. Install CoreDNS
+
+Install CoreDNS using the package/release method appropriate for the operating system. This repository does not ship another service unit; use the CoreDNS service supplied by your package/deployment.
+
+Copy the example configuration to the location used by that installation, commonly `/etc/coredns/Corefile`:
+
+```bash
+sudo mkdir -p /etc/coredns
+sudo cp dns/Corefile.example /etc/coredns/Corefile
+```
+
+Edit it and replace:
+
+- `203.0.113.10` and `203.0.113.11` with the two interruption IPs.
+- the A answer address with the IP on which Caddy should serve the expiration page.
+
+The configuration answers every A query with the interruption web IP, returns a null MX (`0 .`) so the interrupted domain does not direct mail to the web host, and returns authoritative empty answers for other record types. CoreDNS' `template` plugin supports `ANY` as a wildcard query type, so no zone needs to be generated for each expired domain.
+
+Validate/restart CoreDNS using the commands supplied by your installation.
+
+Example checks:
+
+```bash
+dig @203.0.113.10 example.com A
+dig @203.0.113.11 example.net A
+dig @203.0.113.10 example.com MX
+```
+
+The A queries should return the configured interruption web IP.
+
+## 3. Add the expiration page to Caddy
+
+Create the document root and copy the supplied page:
+
+```bash
+sudo mkdir -p /var/www/namingo-expired
+sudo cp dns/index.html /var/www/namingo-expired/index.html
+```
+
+Before deployment, edit `index.html` and replace these placeholders:
+
+```text
+https://registrar.example.com/clientarea/
+https://registrar.example.com/contact/
+```
+
+The first URL should lead the registrant to the registrar account/domain-renewal flow. The second should lead to registrar support.
+
+Then append the block from `Caddyfile.example` to the existing `/etc/caddy/Caddyfile` and replace the two example IP addresses.
+
+The important part is:
+
+```caddyfile
+http:// {
+    bind 203.0.113.10 203.0.113.11
+    root * /var/www/namingo-expired
+    try_files {path} /index.html
+    file_server
+}
+```
+
+`http://` is a hostless HTTP catch-all, so it accepts requests whose Host header is any interrupted customer domain. `bind` confines that catch-all to the dedicated interruption IPs and avoids making it the fallback site on the registrar's normal addresses.
+
+Validate and reload Caddy:
+
+```bash
+sudo caddy validate --config /etc/caddy/Caddyfile
+sudo systemctl reload caddy
+```
+
+A useful local test, before changing any real delegation, is:
+
+```bash
+curl -H 'Host: expired-example.test' http://203.0.113.10/
+```
+
+It should return the expiration page.
+
+## 4. Configure Namingo Registrar
+
+In `automation/config.php`, configure the interruption nameservers already supported by `errp_dns.php`:
+
+```php
+'errp' => [
+    'nameservers' => [
+        'ns1.expired.registrar.example',
+        'ns2.expired.registrar.example',
+    ],
+    'tlds' => [],
+],
+```
+
+`automation/errp_dns.php` remains responsible for deciding which domains are in scope, saving their original nameservers, changing the registry delegation, and restoring the original DNS after renewal. The service in this directory has no registrar database access and does not need a list of expired domains.
+
+## 5. End-to-end test
+
+Before production use, test with a controlled domain:
+
+1. Delegate it to the two interruption nameservers.
+2. Confirm both nameservers answer over UDP and TCP.
+3. Confirm `dig domain.example A` returns the interruption web IP.
+4. Open `http://domain.example/` and verify that the expiration/renewal notice is displayed.
+5. Restore the original nameservers and confirm normal resolution returns.
+
+## HTTPS
+
+This example intentionally serves the interruption page over HTTP only. Caddy cannot present a valid certificate for arbitrary unrelated expired domains without obtaining certificates dynamically for those domains. That adds certificate issuance, validation, abuse and rate-limit concerns that are unnecessary for the ERRP interruption page.
+
+Do not enable catch-all On-Demand TLS merely for this feature unless the operational and certificate-policy implications have been reviewed separately.
+
+## DNSSEC warning
+
+A domain with a DS record at the parent can fail DNSSEC validation after its authoritative nameservers are replaced if the interruption service is not serving a matching signed zone. In that case validating resolvers may return `SERVFAIL` before a browser can reach this page.
+
+DNSSEC handling therefore belongs in the registrar-side ERRP interruption/restoration workflow: any required DS/DNSSEC state must be handled safely and restored together with the registrant's original DNS configuration. Do not assume that changing nameservers alone is sufficient for DNSSEC-enabled domains.
+
+## ERRP page requirement
+
+The supplied page explicitly states that the registration has expired and gives the registrant renewal instructions. Keep those two elements conspicuous if the HTML is customized.

--- a/dns/index.html
+++ b/dns/index.html
@@ -1,0 +1,150 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="robots" content="noindex, nofollow, noarchive">
+    <title>Domain Expired</title>
+    <style>
+        :root {
+            color-scheme: light;
+            font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+            background: #f6f7fb;
+            color: #182033;
+        }
+
+        * { box-sizing: border-box; }
+
+        body {
+            min-height: 100vh;
+            margin: 0;
+            display: grid;
+            place-items: center;
+            padding: 32px 20px;
+            background:
+                radial-gradient(circle at 15% 15%, rgba(99, 102, 241, .10), transparent 30rem),
+                radial-gradient(circle at 85% 80%, rgba(14, 165, 233, .08), transparent 28rem),
+                #f6f7fb;
+        }
+
+        main {
+            width: min(680px, 100%);
+            background: rgba(255, 255, 255, .94);
+            border: 1px solid #e5e7eb;
+            border-radius: 24px;
+            padding: clamp(28px, 6vw, 56px);
+            box-shadow: 0 24px 70px rgba(24, 32, 51, .10);
+        }
+
+        .mark {
+            display: inline-flex;
+            align-items: center;
+            gap: 10px;
+            margin-bottom: 30px;
+            font-size: 14px;
+            font-weight: 700;
+            letter-spacing: .02em;
+            color: #4f46e5;
+        }
+
+        .dot {
+            width: 11px;
+            height: 11px;
+            border-radius: 999px;
+            background: #f59e0b;
+            box-shadow: 0 0 0 7px rgba(245, 158, 11, .12);
+        }
+
+        h1 {
+            margin: 0 0 18px;
+            font-size: clamp(38px, 7vw, 62px);
+            line-height: .98;
+            letter-spacing: -.045em;
+        }
+
+        p {
+            margin: 0;
+            font-size: 18px;
+            line-height: 1.65;
+            color: #556074;
+        }
+
+        .notice {
+            margin: 30px 0;
+            padding: 22px 24px;
+            border-radius: 16px;
+            background: #f8fafc;
+            border: 1px solid #e5e7eb;
+        }
+
+        .notice strong {
+            display: block;
+            margin-bottom: 6px;
+            color: #182033;
+        }
+
+        .actions {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 12px;
+            margin-top: 30px;
+        }
+
+        a {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            min-height: 48px;
+            padding: 0 20px;
+            border-radius: 12px;
+            font-weight: 700;
+            text-decoration: none;
+        }
+
+        .primary {
+            background: #182033;
+            color: #fff;
+        }
+
+        .secondary {
+            color: #374151;
+            border: 1px solid #d1d5db;
+            background: #fff;
+        }
+
+        footer {
+            margin-top: 34px;
+            padding-top: 22px;
+            border-top: 1px solid #eef0f4;
+            font-size: 13px;
+            color: #8a93a3;
+        }
+    </style>
+</head>
+<body>
+<main>
+    <div class="mark"><span class="dot"></span> Domain status notice</div>
+
+    <h1>This domain has expired.</h1>
+
+    <p>
+        The registration for this domain name has expired and its normal DNS service has been temporarily interrupted.
+    </p>
+
+    <div class="notice">
+        <strong>Are you the domain registrant?</strong>
+        <p>Sign in to your registrar account and renew the domain, if it is still eligible for renewal. If you need assistance, contact your registrar's support team.</p>
+    </div>
+
+    <div class="actions">
+        <!-- Replace these two URLs before deployment. -->
+        <a class="primary" href="https://registrar.example.com/clientarea/">Renew domain</a>
+        <a class="secondary" href="https://registrar.example.com/contact/">Contact support</a>
+    </div>
+
+    <footer>
+        This page is displayed because the domain registration has expired. Normal DNS service will be restored after successful renewal when applicable.
+    </footer>
+</main>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Add a minimal packaged DNS/web service for the ERRP DNS interruption already performed by `automation/errp_dns.php`.

The implementation deliberately has no database or billing-system coupling. CoreDNS answers interrupted domains with the interruption web IP and the existing Caddy instance serves a static expiration/renewal page.

## Added

- `dns/Corefile.example`
  - binds CoreDNS to two dedicated interruption IPs
  - resolves all A queries to the interruption web IP
  - returns null MX for interrupted domains
  - returns authoritative empty answers for other record types
- `dns/Caddyfile.example`
  - hostless HTTP catch-all for arbitrary expired domain Host headers
  - binds only to the interruption IPs so normal registrar virtual hosts are unaffected
  - includes conservative cache/privacy/security headers
- `dns/index.html`
  - standalone responsive expiration page
  - conspicuously identifies expiration
  - provides renewal and support instructions/links
  - no external assets or JavaScript
- `dns/README.md`
  - one-host/two-IP deployment example
  - CoreDNS and Caddy setup
  - Namingo `errp.nameservers` configuration
  - end-to-end test procedure
  - HTTP-only rationale
  - DNSSEC/DS warning

## Architecture

```text
errp_dns.php -> registry NS change -> CoreDNS :53 -> interruption IP -> Caddy :80 -> expiration page
```

The DNS/web host does not need to know which domains are expired. Registry delegation determines which domains reach the service.

## Notes

Two IP addresses may be hosted on one server for a minimal deployment, but this does not provide infrastructure redundancy. The README recommends independent hosts/networks where HA is required.

DNSSEC handling is intentionally not implemented in this directory. Domains retaining a DS record at the parent may fail validation after an NS replacement, so DS/DNSSEC state needs to be handled safely in the registrar-side interruption/restoration workflow.