### PR TITLE
Fix WHMCS Monolog autoloader collision

### DIFF
--- a/automation/helpers.php
+++ b/automation/helpers.php
@@ -10,6 +10,11 @@ use Pinga\Tembo\EppRegistryFactory;
 use PHPMailer\PHPMailer\PHPMailer;
 use PHPMailer\PHPMailer\Exception as PHPMailerException;
 
+// Let WHMCS load its matching Monolog classes before the logger is created.
+if (strcasecmp(trim((string)($config['escrow']['backend'] ?? '')), 'WHMCS') === 0) {
+    require_once '/var/www/whmcs/init.php';
+}
+
 function epp_client($config)
 {
     $profile = $config['registrar'] ?? 'namingo';


### PR DESCRIPTION
## Summary

- bootstrap WHMCS in `automation/helpers.php` before `setupLogger()` can instantiate Monolog classes
- apply the bootstrap only when `escrow.backend` is `WHMCS`
- keep the automation `monolog/monolog` 3.x dependency unchanged
- fix the shared startup path used by `errp_dns.php`, `epp_poll.php`, and the other automation jobs

## Why

The automation Composer loader is registered first. WHMCS is then bootstrapped before any Monolog class is instantiated, so WHMCS's later-priority Composer loader supplies the internally compatible Monolog classes and handlers. This prevents WHMCS's array-record handlers from being declared against Monolog 3's `LogRecord` base signature.

## Validation

- parsed all 26 PHP files under `automation/` in PHP 8.3 mode
- `git diff --check`
- no Composer, database, or cron-logic changes