### PR TITLE
Reopen validation after admin unvalidation

### DIFF
--- a/automation/validation.php
+++ b/automation/validation.php
@@ -139,6 +139,22 @@ function validationState(PDO $pdo, int $id): array
     return $state;
 }
 
+function validationBillingRevalidationRequested(
+    array $row,
+    array $state,
+    DateTimeImmutable $now
+): bool {
+    if (($state['status'] ?? null) !== 'verified'
+        || (int)($row['validation'] ?? 0) !== 0
+        || empty($state['verified_at'])) {
+        return false;
+    }
+
+    $verifiedAt = validationDate($state['verified_at'], $now);
+    $checkedAt = $row['validation_checked_at'] ?? $row['validation_stamp'] ?? null;
+    return validationDate($checkedAt, $verifiedAt) > $verifiedAt;
+}
+
 function validationHasVerifiedHash(
     PDO $pdo,
     string $verificationKey,
@@ -572,6 +588,15 @@ function runValidation(): int
                 $commandMatched = true;
             }
             $forcedTrigger = $isTarget ? $trigger : null;
+            if ($forcedTrigger === null
+                && $state !== null
+                && validationBillingRevalidationRequested($row, $state, $now)) {
+                $forcedTrigger = 'manual';
+                $log->info(
+                    'Billing contact was marked unvalidated; reopened validation for '
+                        . $row['domain_name'] . '.'
+                );
+            }
 
             if ($state === null) {
                 $triggeredAt = validationDate($row['registered_at'] ?? null, $now);


### PR DESCRIPTION
## Summary

- detect when a billing contact is explicitly marked unvalidated after its current domain-validation case was verified
- route that event through the existing manual-trigger transition so the verified case is closed, a pending case is created, and a new token/email is issued in the same cron run
- ignore stale zero flags, already-pending cases, and billing timestamps older than the completed verification

The timestamp guard prevents a revalidation loop from cron-written token updates. The change uses the normalized `validation_checked_at`/`validation_stamp` values already returned by the bundled billing drivers.

No database or billing-module changes are required.

## Verification

- `automation/validation.php` parses successfully
- `git diff --check` passes
- checked newer/older timestamps, validated flags, and verified/pending state scenarios